### PR TITLE
chore: trivy, charts, veracode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=1.9.5-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
       - name: Conforming Container Build and Push
@@ -152,6 +154,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=1.9.5-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
       - name: Remoting Container Build and Push
@@ -189,6 +193,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=1.9.5-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
       - name: Provisioning Container Build and Push

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -87,6 +87,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
+      # We need to login
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          # Use existing DockerHub credentials present as secrets
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
         ## This step will fail if the docker images is not found
       - name: "Check if image exists"
         id: imageCheck

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Verify proper formatting
         run: ./mvnw spotless:check
 
-  build:
+  build_standalone:
     runs-on: ubuntu-latest
     needs: [ secret-presence, verify-formatting ]
     permissions:
@@ -57,8 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [ { dir: provisioning, name: provisioning-agent },
-                   { dir: remoting, name: remoting-agent },
+        variant: [ { dir: remoting, name: remoting-agent },
                    { dir: conforming, name: conforming-agent }
                   ]
     steps:
@@ -75,6 +74,43 @@ jobs:
       - name: Tar gzip files for veracode upload
         run: |-
           tar -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
+      - name: Veracode Upload And Scan
+        uses: veracode/veracode-uploadandscan-action@v1.0
+        if: |
+          needs.secret-presence.outputs.ORG_VERACODE_API_ID && needs.secret-presence.outputs.ORG_VERACODE_API_KEY
+        continue-on-error: true
+        with:
+          appname: knowledge-agents/${{ matrix.variant.name }}
+          createprofile: true
+          version: ${{ matrix.variant.name }}-${{ github.sha }}
+          filepath: ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz
+          vid: ${{ secrets.ORG_VERACODE_API_ID }}
+          vkey: ${{ secrets.ORG_VERACODE_API_KEY }}
+
+  build_embedded:
+    runs-on: ubuntu-latest
+    needs: [ secret-presence, verify-formatting ]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [ { dir: provisioning, name: provisioning-agent },
+        ]
+    steps:
+      # Set-Up
+      - uses: actions/checkout@v3.5.2
+      - uses: ./.github/actions/setup-java
+      # Build
+      - name: Build ${{ matrix.variant.name }}
+        run: |-
+          ./mvnw -s settings.xml -pl ${{ matrix.variant.dir }} install
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tar gzip files for veracode upload
+        run: |-
+          tar -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/lib/*.jar ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@v1.0
         if: |

--- a/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/SparqlProvider.java
+++ b/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/SparqlProvider.java
@@ -42,8 +42,9 @@ public class SparqlProvider implements MessageBodyReader, MessageBodyWriter {
 
     @Override
     public Object readFrom(Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, InputStream inputStream) throws IOException, WebApplicationException {
-        return new BufferedReader(new InputStreamReader(inputStream))
-                .lines().collect(Collectors.joining("\n"));
+        try (BufferedReader reader=new BufferedReader(new InputStreamReader(inputStream))) {
+            return reader.lines().collect(Collectors.joining("\n"));
+        }
     }
 
     @Override

--- a/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
+++ b/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
@@ -69,7 +69,9 @@ public class XmlProvider implements MessageBodyReader, MessageBodyWriter {
     @Override
     public void writeTo(Object o, Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
         try {
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            TransformerFactory factory = TransformerFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Transformer transformer = factory.newTransformer();
             transformer.transform(new DOMSource((Document) o),new StreamResult(outputStream));
         } catch (TransformerException e) {
             throw new IOException("Cannot render xml body",e);


### PR DESCRIPTION
## WHAT

- Improve workflows
- Fix some SAST hints

## WHY

- SNAPSHOT chart should be able to find SNAPSHOT or latest image
- trivy step was disabled because docker manifest check requires a login
- veracode brought 2 hints (informational, medium) for conforming agent
- veracode did not correctly scan provisioning agent
- veracode did not scan remoting agent at all (https://github.com/eclipse-tractusx/sig-infra/issues/237)

## FURTHER NOTES

Could you please also start veracode manually after merge (and fixing https://github.com/eclipse-tractusx/sig-infra/issues/237)? Big hug from me!