### PR TITLE
Add maven plugin to generate DEPENDENCIES via Dash

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -47,6 +47,7 @@ maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-lang/commons-lang/2.6, Apache-2.0, approved, CQ6183
+maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.micrometer/micrometer-core/1.9.12, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7711
 maven/mavencentral/io.mikael/urlbuilder/2.0.9, Apache-2.0, approved, #9815
@@ -298,7 +299,7 @@ maven/mavencentral/org.thymeleaf.extras/thymeleaf-extras-java8time/3.0.4.RELEASE
 maven/mavencentral/org.thymeleaf/thymeleaf-spring5/3.0.15.RELEASE, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.thymeleaf/thymeleaf/3.0.15.RELEASE, EPL-2.0, approved, CQ22180
 maven/mavencentral/org.unbescape/unbescape/1.1.6.RELEASE, Apache-2.0, approved, CQ18904
-maven/mavencentral/org.xerial.snappy/snappy-java/1.1.7.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
+maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.2, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.yaml/snakeyaml/1.30, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,9 @@
 maven/mavencentral/aopalliance/aopalliance/1.0, LicenseRef-Public-Domain, approved, CQ2918
 maven/mavencentral/ch.qos.logback/logback-classic/1.2.11, EPL-1.0, approved, CQ13636
+maven/mavencentral/ch.qos.logback/logback-classic/1.2.12, EPL-1.0, approved, CQ13636
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.8, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-core/1.2.11, EPL-1.0, approved, CQ13635
+maven/mavencentral/ch.qos.logback/logback-core/1.2.12, EPL-1.0, approved, CQ13635
 maven/mavencentral/ch.qos.logback/logback-core/1.4.8, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.4, Apache-2.0, approved, clearlydefined
@@ -15,13 +17,16 @@ maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-guava/2.13.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.13.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-joda/2.15.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.13.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.15.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.15.2, Apache-2.0, approved, #9101
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.15.2, Apache-2.0, approved, #9100
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.13.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.13.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.woodstox/woodstox-core/6.5.1, Apache-2.0, approved, #7950
 maven/mavencentral/com.github.jsonld-java/jsonld-java/0.13.4, BSD-3-Clause, approved, CQ22136
 maven/mavencentral/com.github.jsqlparser/jsqlparser/4.4, LGPL-2.1 OR Apache-2.0, approved, clearlydefined
@@ -33,16 +38,27 @@ maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-confl
 maven/mavencentral/com.google.inject.extensions/guice-assistedinject/5.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.inject/guice/5.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.jayway.jsonpath/json-path/2.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.opencsv/opencsv/5.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.14, Apache-2.0, approved, clearlydefined
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-lang/commons-lang/2.6, Apache-2.0, approved, CQ6183
-maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
+maven/mavencentral/io.micrometer/micrometer-core/1.9.12, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7711
 maven/mavencentral/io.mikael/urlbuilder/2.0.9, Apache-2.0, approved, #9815
+maven/mavencentral/io.netty/netty-buffer/4.1.94.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.94.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.94.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.94.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.sgr/s2-geometry-library-java/1.0.0, Apache-2.0, approved, CQ22121
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.2.12, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.12, Apache-2.0, approved, #9265
@@ -54,6 +70,7 @@ maven/mavencentral/it.unibz.inf.ontop/ontop-obda-core/5.0.2, Apache-2.0, approve
 maven/mavencentral/it.unibz.inf.ontop/ontop-rdb/5.0.2, Apache-2.0, approved, #9813
 maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/1.3.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
+maven/mavencentral/jakarta.servlet/jakarta.servlet-api/4.0.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.servlet
 maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/2.1.6, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.rest
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3, BSD-3-Clause, approved, ee4j.jaxb
@@ -63,6 +80,10 @@ maven/mavencentral/javax.servlet/servlet-api/2.5, Apache-2.0, approved, CQ1961
 maven/mavencentral/javax.validation/validation-api/2.0.1.Final, Apache-2.0, approved, CQ15302
 maven/mavencentral/javax.xml.bind/jaxb-api/2.3.0, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16911
 maven/mavencentral/joda-time/joda-time/2.10.14, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.10.20, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.bytebuddy/byte-buddy/1.10.20, , approved, CQ22491
+maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
+maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-math3/3.6.1, Apache-2.0 AND BSD-3-Clause AND BSD-2-Clause, approved, CQ22025
@@ -84,6 +105,7 @@ maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.14, Apache-2.0, approv
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.17.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.17.2, Apache-2.0, approved, #2163
 maven/mavencentral/org.apache.lucene/lucene-analyzers-common/8.9.0, Apache-2.0 AND BSD-3-Clause AND LicenseRef-scancode-iso-8879, approved, #6152
+maven/mavencentral/org.apache.lucene/lucene-backward-codecs/8.9.0, Apache-2.0, approved, #6151
 maven/mavencentral/org.apache.lucene/lucene-core/8.9.0, Apache-2.0 AND BSD-3-Clause AND NCSA AND ISC AND LicenseRef-scancode-sunpro AND ICU AND LicenseRef-scancode-unicode-mappings AND BSD-3-Clause AND MIT AND BSD-2-Clause, approved, #6155
 maven/mavencentral/org.apache.lucene/lucene-highlighter/8.9.0, Apache-2.0, approved, #6137
 maven/mavencentral/org.apache.lucene/lucene-memory/8.9.0, Apache-2.0, approved, #6136
@@ -93,8 +115,18 @@ maven/mavencentral/org.apache.lucene/lucene-sandbox/8.9.0, Apache-2.0, approved,
 maven/mavencentral/org.apache.lucene/lucene-spatial-extras/8.9.0, Apache-2.0, approved, #6138
 maven/mavencentral/org.apache.lucene/lucene-spatial3d/8.9.0, Apache-2.0, approved, #6140
 maven/mavencentral/org.apache.solr/solr-solrj/8.9.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #6141
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/9.0.76, Apache-2.0 AND (CDDL-1.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, CQ20188
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/9.0.78, Apache-2.0 AND (CDDL-1.0 OR GPL-2.0 WITH Classpath-exception-2.0), approved, CQ20188
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/9.0.76, Apache-2.0, approved, CQ20193
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/9.0.78, Apache-2.0, approved, CQ20193
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/9.0.76, Apache-2.0, approved, CQ20194
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/9.0.78, Apache-2.0, approved, CQ20194
+maven/mavencentral/org.apache.tomcat/tomcat-annotations-api/9.0.78, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.zookeeper/zookeeper-jute/3.6.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.zookeeper/zookeeper/3.6.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.assertj/assertj-core/3.19.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.attoparser/attoparser/2.0.5.RELEASE, Apache-2.0, approved, CQ18900
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.woodstox/stax2-api/3.1.4, BSD-2-Clause, approved, CQ13504
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
@@ -103,6 +135,12 @@ maven/mavencentral/org.eclipse.jetty.http2/http2-client/9.4.50.v20221201, EPL-2.
 maven/mavencentral/org.eclipse.jetty.http2/http2-common/9.4.50.v20221201, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.http2/http2-hpack/9.4.50.v20221201, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.http2/http2-http-client-transport/9.4.50.v20221201, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-alpn-client/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-alpn-java-client/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-client/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-http/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-io/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
+maven/mavencentral/org.eclipse.jetty/jetty-util/9.4.51.v20230217, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.rdf4j/rdf4j-client/4.3.3, BSD-3-Clause, approved, technology.rdf4j
 maven/mavencentral/org.eclipse.rdf4j/rdf4j-collection-factory-api/4.3.3, BSD-3-Clause, approved, technology.rdf4j
 maven/mavencentral/org.eclipse.rdf4j/rdf4j-collection-factory-mapdb/4.3.3, BSD-3-Clause, approved, technology.rdf4j
@@ -184,34 +222,68 @@ maven/mavencentral/org.glassfish.hk2/hk2-api/2.6.1, EPL-2.0 OR GPL-2.0-only with
 maven/mavencentral/org.glassfish.hk2/hk2-locator/2.6.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/2.6.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, CDDL-1.0, approved, CQ10889
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.containers/jersey-container-simple-http/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.core/jersey-client/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.core/jersey-common/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.core/jersey-server/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.test-framework.providers/jersey-test-framework-provider-simple/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.test-framework/jersey-test-framework-core/2.40, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
 maven/mavencentral/org.javabits.jgrapht/jgrapht-core/0.9.3, EPL-2.0 OR LGPL-2.1-or-later, approved, #9816
 maven/mavencentral/org.javassist/javassist/3.29.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #6023
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.8.2, EPL-2.0, approved, #1291
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.0, EPL-2.0, approved, #3133
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.8.2, EPL-2.0, approved, #1292
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.0, EPL-2.0, approved, #3125
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.8.2, EPL-2.0, approved, #1488
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.0, EPL-2.0, approved, #3134
+maven/mavencentral/org.junit.jupiter/junit-jupiter/5.8.2, EPL-2.0, approved, clearlydefined
+maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.0, EPL-2.0, approved, #6972
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.8.2, EPL-2.0, approved, #1288
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.0, EPL-2.0, approved, #3130
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.8.2, EPL-2.0, approved, #1289
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.0, EPL-2.0, approved, #3128
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484
+maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.locationtech.jts/jts-core/1.18.1, EPL-2.0, approved, locationtech.jts
 maven/mavencentral/org.locationtech.proj4j/proj4j/1.1.1, Apache-2.0, approved, locationtech.proj4j
 maven/mavencentral/org.locationtech.spatial4j/spatial4j/0.8, Apache-2.0, approved, locationtech.spatial4j
 maven/mavencentral/org.lwjgl/lwjgl-lmdb/3.3.1, BSD-3-Clause, approved, #3055
 maven/mavencentral/org.lwjgl/lwjgl/3.3.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.mapdb/mapdb/1.0.8, Apache-2.0, approved, CQ8246
+maven/mavencentral/org.mockito/mockito-core/3.8.0, MIT, approved, clearlydefined
+maven/mavencentral/org.mockito/mockito-junit-jupiter/3.8.0, MIT, approved, clearlydefined
+maven/mavencentral/org.objenesis/objenesis/3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.simpleframework/simple-common/6.0.1, Apache-2.0, approved, CQ16868
 maven/mavencentral/org.simpleframework/simple-http/6.0.1, Apache-2.0, approved, CQ16869
 maven/mavencentral/org.simpleframework/simple-transport/6.0.1, Apache-2.0, approved, CQ16870
+maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.slf4j/jcl-over-slf4j/1.7.32, Apache-2.0, approved, CQ12843
 maven/mavencentral/org.slf4j/jcl-over-slf4j/1.7.36, Apache-2.0, approved, CQ12843
 maven/mavencentral/org.slf4j/jul-to-slf4j/1.7.36, MIT, approved, CQ12842
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-simple/2.0.7, MIT, approved, clearlydefined
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/2.7.13, Apache-2.0, approved, #3273
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/2.7.13, Apache-2.0, approved, #4316
 maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/2.7.13, Apache-2.0, approved, #4314
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/2.7.13, Apache-2.0, approved, #4318
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/2.7.13, Apache-2.0, approved, #4307
 maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/2.7.13, Apache-2.0, approved, #4327
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/2.7.13, Apache-2.0, approved, #4320
+maven/mavencentral/org.springframework.boot/spring-boot-starter-thymeleaf/2.7.13, Apache-2.0, approved, #4350
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/2.7.13, Apache-2.0, approved, #4305
 maven/mavencentral/org.springframework.boot/spring-boot-starter-web/2.7.13, Apache-2.0, approved, #4304
 maven/mavencentral/org.springframework.boot/spring-boot-starter/2.7.13, Apache-2.0, approved, #4308
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/2.7.13, Apache-2.0, approved, #4313
+maven/mavencentral/org.springframework.boot/spring-boot-test/2.7.13, Apache-2.0, approved, #4323
 maven/mavencentral/org.springframework.boot/spring-boot/2.7.13, Apache-2.0, approved, #4322
 maven/mavencentral/org.springframework/spring-aop/5.3.28, Apache-2.0, approved, CQ23152
 maven/mavencentral/org.springframework/spring-beans/5.3.28, Apache-2.0, approved, CQ23153
@@ -219,7 +291,14 @@ maven/mavencentral/org.springframework/spring-context/5.3.28, Apache-2.0, approv
 maven/mavencentral/org.springframework/spring-core/5.3.28, Apache-2.0 AND BSD-3-Clause, approved, CQ23154
 maven/mavencentral/org.springframework/spring-expression/5.3.28, Apache-2.0, approved, CQ23155
 maven/mavencentral/org.springframework/spring-jcl/5.3.28, Apache-2.0, approved, CQ23156
+maven/mavencentral/org.springframework/spring-test/5.3.28, Apache-2.0, approved, CQ23054
 maven/mavencentral/org.springframework/spring-web/5.3.28, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23157
 maven/mavencentral/org.springframework/spring-webmvc/5.3.28, Apache-2.0, approved, CQ23158
-maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.2, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
+maven/mavencentral/org.thymeleaf.extras/thymeleaf-extras-java8time/3.0.4.RELEASE, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.thymeleaf/thymeleaf-spring5/3.0.15.RELEASE, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.thymeleaf/thymeleaf/3.0.15.RELEASE, EPL-2.0, approved, CQ22180
+maven/mavencentral/org.unbescape/unbescape/1.1.6.RELEASE, Apache-2.0, approved, CQ18904
+maven/mavencentral/org.xerial.snappy/snappy-java/1.1.7.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
+maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
+maven/mavencentral/org.yaml/snakeyaml/1.30, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ To publish the binary artifacts (environment variables GITHUB_ACTOR and GITHUB_T
 ./mvnw -s settings.xml publish
 ```
 
+To update the [DEPENDENCIES](./DEPENDENCIES) declarations
+
+```shell
+./mvnw org.eclipse.dash:license-tool-plugin:license-check 
+```
+
 ### Deployment
 
 Deployment can be done

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- REPO -->
         <repo>tractusx/</repo>
         <platform>linux/amd64</platform>
-    </properties>    
+    </properties>
     <modules>
         <module>provisioning</module>
         <module>remoting</module>
@@ -93,6 +93,24 @@
         <pluginManagement>
 
             <plugins>
+                <plugin>
+                    <groupId>org.eclipse.dash</groupId>
+                    <artifactId>license-tool-plugin</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <configuration>
+                        <projectId>automotive.tractusx</projectId>
+                        <summary>DEPENDENCIES</summary>
+                        <includeScope>test</includeScope>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>license-check</id>
+                            <goals>
+                                <goal>license-check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
## WHAT

Add a maven plugin for [Eclipse Dash Licenses](https://github.com/eclipse/dash-licenses).

## WHY

This should make it easier to keep the `DEPENDENCIES` file up-to-date

## FURTHER NOTES

This is just a suggestion. Running Dash can also be done via standalone .jar.
It seems like the maven setup of this repo makes it slightly more complicated, since the dependencies summary will end up in separate files per module, that need to be merged before running Dash
