### PR TITLE
docs|fix|chore(provisioning-agent): SAST Flaws and CHANGELOG

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Verify proper formatting
         run: ./mvnw spotless:check
 
+###
+# Standalone applications have all dependencies in their jar
+###
   build_standalone:
     runs-on: ubuntu-latest
     needs: [ secret-presence, verify-formatting ]
@@ -87,6 +90,13 @@ jobs:
           vid: ${{ secrets.ORG_VERACODE_API_ID }}
           vkey: ${{ secrets.ORG_VERACODE_API_KEY }}
 
+###
+# Embedded applications need dependencies being provided.
+# Expecially wrt. Spring 5.3.28 Web there is an open HIGH vulnerability regarding
+# org/springframework/remoting/httpinvoker which will not be fixed
+# so we manipulate the jar in the docker environment directly and exclude
+# the dependency from the scan
+###
   build_embedded:
     runs-on: ubuntu-latest
     needs: [ secret-presence, verify-formatting ]
@@ -110,7 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tar gzip files for veracode upload
         run: |-
-          tar -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/lib/*.jar ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
+          tar --exclude='spring-web-5.3.28.jar' -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/lib/*.jar ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@v1.0
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ All notable changes to this product will be documented in this file.
 
 # Released
 
-# Unreleased
-
-## [1.9.5-SNAPSHOT] - 
+## [1.9.5] - 
 
 ### Added
 
@@ -39,6 +37,8 @@ All notable changes to this product will be documented in this file.
 - Eclipse Tractus-X standards and migration
 
 ### Removed
+
+# Unreleased
 
 ## [0.8.6] - 2023-05-19
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -262,6 +262,7 @@ maven/mavencentral/org.mockito/mockito-junit-jupiter/3.8.0, MIT, approved, clear
 maven/mavencentral/org.objenesis/objenesis/3.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
+maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
 maven/mavencentral/org.simpleframework/simple-common/6.0.1, Apache-2.0, approved, CQ16868
 maven/mavencentral/org.simpleframework/simple-http/6.0.1, Apache-2.0, approved, CQ16869
 maven/mavencentral/org.simpleframework/simple-transport/6.0.1, Apache-2.0, approved, CQ16870
@@ -301,5 +302,4 @@ maven/mavencentral/org.thymeleaf/thymeleaf/3.0.15.RELEASE, EPL-2.0, approved, CQ
 maven/mavencentral/org.unbescape/unbescape/1.1.6.RELEASE, Apache-2.0, approved, CQ18904
 maven/mavencentral/org.xerial.snappy/snappy-java/1.1.10.2, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9098
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
-maven/mavencentral/org.yaml/snakeyaml/1.30, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
+++ b/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
@@ -70,8 +70,8 @@ public class XmlProvider implements MessageBodyReader, MessageBodyWriter {
     public void writeTo(Object o, Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
         try {
             TransformerFactory factory = TransformerFactory.newInstance();
-            factory.setAttribute(“http://javax.xml.XMLConstants/property/accessExternalDTD”,””);
-            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet",””);            
+            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD","");
+            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet","");
             Transformer transformer = factory.newTransformer();
             transformer.transform(new DOMSource((Document) o),new StreamResult(outputStream));
         } catch (TransformerException e) {

--- a/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
+++ b/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
@@ -70,7 +70,8 @@ public class XmlProvider implements MessageBodyReader, MessageBodyWriter {
     public void writeTo(Object o, Class aClass, Type type, Annotation[] annotations, MediaType mediaType, MultivaluedMap multivaluedMap, OutputStream outputStream) throws IOException, WebApplicationException {
         try {
             TransformerFactory factory = TransformerFactory.newInstance();
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setAttribute(“http://javax.xml.XMLConstants/property/accessExternalDTD”,””);
+            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet",””);            
             Transformer transformer = factory.newTransformer();
             transformer.transform(new DOMSource((Document) o),new StreamResult(outputStream));
         } catch (TransformerException e) {

--- a/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
+++ b/conforming/src/gen/java/org/eclipse/tractusx/agents/conforming/api/XmlProvider.java
@@ -41,6 +41,10 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+/**
+ * This class provides a MessageBodyReader and MessageBodyWriter for XML content type.
+ * It prevents access to external DTDs and stylesheets while reading and writing XML.
+ */
 @Provider
 public class XmlProvider implements MessageBodyReader, MessageBodyWriter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <jetty.version>9.4.51.v20230217</jetty.version>
         <org.yaml.snakeyaml.version>2.0</org.yaml.snakeyaml.version>
         <snappy.version>1.1.10.2</snappy.version>
+        <postgres.version>42.6.0</postgres.version>
         <!-- REPO -->
         <repo>tractusx/</repo>
         <platform>linux/amd64</platform>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,16 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+	    <pluginRepository>
+		<id>dash-licenses-snapshots</id>
+		<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+		<snapshots>
+			<enabled>true</enabled>
+		</snapshots>
+	    </pluginRepository>
+    </pluginRepositories>
+
     <distributionManagement>
         <repository>
             <id>github</id>

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -62,6 +62,11 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
             <version>${tomcat.version}</version>
@@ -89,6 +94,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -112,6 +123,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgres.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/provisioning/src/main/docker/Dockerfile
+++ b/provisioning/src/main/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN rm /opt/ontop/lib/guava-*.jar && \
     for jdbcDriver in "$jdbcDrivers"; do wget --no-check-certificate -q -P /opt/ontop/jdbc ${jdbcDriver} ; done && \
     mkdir -p /opt/ontop/input && \
     mkdir -p /opt/ontop/database && \
-    chmod 755 /opt/ontop/entrypoint.sh && \
+    chmod 700 /opt/ontop/entrypoint.sh && \
     chown -R ontop:ontop /opt/ontop
 
 COPY --from=build /opt/ontop/lib/*.jar /opt/ontop/lib/

--- a/provisioning/src/main/docker/Dockerfile
+++ b/provisioning/src/main/docker/Dockerfile
@@ -21,14 +21,11 @@
 
 FROM openjdk:22-jdk-slim AS build
 
-
 COPY target/provisioning-agent-*.jar /opt/ontop/lib/
 COPY target/lib/guava-*.jar /opt/ontop/lib/
 COPY target/lib/tomcat-embed-*.jar /opt/ontop/lib/
 COPY target/lib/spring-*.jar /opt/ontop/lib/
-COPY target/lib/guava-*.jar /opt/ontop/lib/
-COPY target/lib/tomcat-embed-*.jar /opt/ontop/lib/
-COPY target/lib/spring-*.jar /opt/ontop/lib/
+COPY target/lib/postgresql-*.jar /opt/ontop/jdbc/
 
 WORKDIR /tmp
 
@@ -49,7 +46,7 @@ USER root
 COPY resources/entrypoint.sh /opt/ontop/.
 
 # run with docker --build-arg jdbcDrivers=path_to_my_driver to establish a different driver
-ARG jdbcDrivers="https://repo1.maven.org/maven2/org/postgresql/postgresql/42.5.2/postgresql-42.5.2.jar https://repo1.maven.org/maven2/com/h2database/h2/2.2.220/h2-2.2.220.jar https://download.dremio.com/jdbc-driver/dremio-jdbc-driver-LATEST.jar https://repo1.maven.org/maven2/org/apache/calcite/avatica/avatica/1.22.0/avatica-1.22.0.jar"
+ARG jdbcDrivers="https://repo1.maven.org/maven2/com/h2database/h2/2.2.220/h2-2.2.220.jar https://download.dremio.com/jdbc-driver/dremio-jdbc-driver-LATEST.jar https://repo1.maven.org/maven2/org/apache/calcite/avatica/avatica/1.22.0/avatica-1.22.0.jar"
 
 RUN rm /opt/ontop/lib/guava-*.jar && \
     rm /opt/ontop/lib/tomcat-embed-*.jar && \
@@ -62,6 +59,7 @@ RUN rm /opt/ontop/lib/guava-*.jar && \
     chown -R ontop:ontop /opt/ontop
 
 COPY --from=build /opt/ontop/lib/*.jar /opt/ontop/lib/
+COPY --from=build /opt/ontop/jdbc/*.jar /opt/ontop/jdbc/
 
 # Switch back
 USER ontop

--- a/provisioning/src/test/java/org/eclipse/tractusx/agents/AmazonRdsProxyTest.java
+++ b/provisioning/src/test/java/org/eclipse/tractusx/agents/AmazonRdsProxyTest.java
@@ -25,6 +25,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * Amazon RDS behaves sometimes a little bit different than the native DBs
  * This test class is to find out and mitigate the peculiarities.
@@ -32,7 +34,7 @@ import java.util.Properties;
 @Tag("online")
 public class AmazonRdsProxyTest {
 
-    String rdsInstance="jdbc:postgresql://%s.rds.amazonaws.com:5432/postgres?user=%s&password=%s";
+    String rdsInstance="jdbc:postgresql://%s.rds.amazonaws.com:%d/postgres?user=%s&password=%s";
 
     /**
      * tests connection to amazon
@@ -40,8 +42,9 @@ public class AmazonRdsProxyTest {
      */
     @Test
     public void testConnection() throws SQLException {
-        String connectionUrl=String.format(rdsInstance,"database-test.c5yvud9moyda","admin","hello");
+        String connectionUrl=String.format(rdsInstance,"database-x.region",8080,"who","what");
         Properties connectionProperties=new Properties();
         Connection connection=DriverManager.getConnection(connectionUrl, connectionProperties);
+        assertNotNull(connection.getSchema(),"Current schema should be non-empty");
     }
 }

--- a/provisioning/src/test/java/org/eclipse/tractusx/agents/AmazonRdsProxyTest.java
+++ b/provisioning/src/test/java/org/eclipse/tractusx/agents/AmazonRdsProxyTest.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 T-Systems International GmbH
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.agents;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Amazon RDS behaves sometimes a little bit different than the native DBs
+ * This test class is to find out and mitigate the peculiarities.
+ */
+@Tag("online")
+public class AmazonRdsProxyTest {
+
+    String rdsInstance="jdbc:postgresql://%s.rds.amazonaws.com:5432/postgres?user=%s&password=%s";
+
+    /**
+     * tests connection to amazon
+     * @throws SQLException
+     */
+    @Test
+    public void testConnection() throws SQLException {
+        String connectionUrl=String.format(rdsInstance,"database-test.c5yvud9moyda","admin","hello");
+        Properties connectionProperties=new Properties();
+        Connection connection=DriverManager.getConnection(connectionUrl, connectionProperties);
+    }
+}

--- a/remoting/src/main/java/org/eclipse/tractusx/agents/remoting/Invocation.java
+++ b/remoting/src/main/java/org/eclipse/tractusx/agents/remoting/Invocation.java
@@ -284,7 +284,8 @@ public class Invocation {
         } else if(source instanceof Element) {
             try {
                 TransformerFactory transFactory = TransformerFactory.newInstance();
-                transFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                transFactory.setAttribute(“http://javax.xml.XMLConstants/property/accessExternalDTD”,””);
+                transFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet",””);         
                 Transformer transformer = transFactory.newTransformer();
                 StringWriter buffer = new StringWriter();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");

--- a/remoting/src/main/java/org/eclipse/tractusx/agents/remoting/Invocation.java
+++ b/remoting/src/main/java/org/eclipse/tractusx/agents/remoting/Invocation.java
@@ -284,8 +284,8 @@ public class Invocation {
         } else if(source instanceof Element) {
             try {
                 TransformerFactory transFactory = TransformerFactory.newInstance();
-                transFactory.setAttribute(“http://javax.xml.XMLConstants/property/accessExternalDTD”,””);
-                transFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet",””);         
+                transFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD","");
+                transFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet","");
                 Transformer transformer = transFactory.newTransformer();
                 StringWriter buffer = new StringWriter();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");


### PR DESCRIPTION
## WHAT

Addressed four issues from SAST (2*XSLT External Entity Disablement, 2*Discrepancy between unclean maven deps and clean docker runtime)
Already reference upcoming release in CHANGELOG
Include a cloud-based postgres test which reflects a valid deployment scenario (and its current pitfalls).

## WHY

CHANGELOG should reflect release status (TRG)
Render SAST analysis green and close to 100%
include test settings from E2E tests.

## FURTHER NOTES

