### PR TITLE
fix(build): trigger build workflow on pushed tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     # Can be scheduled on all branches and version tags
     tags:
       - 'v*.*.*'
@@ -34,7 +34,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths-ignore:
       - 'charts/**'
       - 'docs/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ on:
     branches:
       - main
       - 'releases/**'
+    # Can be scheduled on all branches and version tags
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
   # Runs automatically on all code-related PRs to main and release branches
   pull_request:
     branches:
@@ -35,13 +39,8 @@ on:
       - 'charts/**'
       - 'docs/**'
       - '**/*.md'
-  # Can be scheduled on all branches and version tags
+  # Manual workflow trigger
   workflow_dispatch:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
-    branches:
-      - '*'
 
 # the docker registry and namespace
 env:
@@ -73,7 +72,7 @@ jobs:
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enabled deployment access (if either running on main or a version tag on eclipse-tractusx) 
+      # Enabled deployment access (if either running on main or a version tag on eclipse-tractusx)
       - name: Login to GitHub Container Registry
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
@@ -82,7 +81,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      # Run Maven Deploy (if either running on main or a version tag on eclipse-tractusx) 
+      # Run Maven Deploy (if either running on main or a version tag on eclipse-tractusx)
       - name: Deploy Java via Maven
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
         run: |
@@ -107,7 +106,7 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/conforming-agent
-          # Automatically prepare image tags; See action docs for more examples. 
+          # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=sha,event=branch
@@ -134,7 +133,7 @@ jobs:
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
-          readme-filepath: conforming/README.md 
+          readme-filepath: conforming/README.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/conforming-agent
@@ -146,7 +145,7 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/remoting-agent
-          # Automatically prepare image tags; See action docs for more examples. 
+          # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=sha,event=branch
@@ -173,7 +172,7 @@ jobs:
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
-          readme-filepath: remoting/README.md 
+          readme-filepath: remoting/README.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/remoting-agent
@@ -185,7 +184,7 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/provisioning-agent
-          # Automatically prepare image tags; See action docs for more examples. 
+          # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=sha,event=branch
@@ -212,8 +211,8 @@ jobs:
         if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
-          readme-filepath: provisioning/README.md 
+          readme-filepath: provisioning/README.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
           repository: ${{ env.IMAGE_NAMESPACE }}/provisioning-agent
-        
+

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -25,14 +25,14 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths:
       - .github/workflows/**
       - charts/**
   pull_request:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths:
       - .github/workflows/**
       - charts/**

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -76,12 +76,12 @@ jobs:
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --target-branch ${{ github.event.ref }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${{ github.event.ref }})
           if [[ -n "$changed" ]]; then
             echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -76,12 +76,12 @@ jobs:
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.ref }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --target-branch ${{ github.base_ref || github.ref_name }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.ref }})
+          changed=$(ct list-changed --target-branch ${{ github.base_ref || github.ref_name }})
           if [[ -n "$changed" ]]; then
             echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -29,7 +29,7 @@ on:
       - 'charts/**'
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
 
 jobs:
   release:

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -22,9 +22,6 @@ name: Release Charts
 on:
   # May be invoked manually
   workflow_dispatch:
-    branches:
-      - main
-      - 'releases/**'
   # Or by pushing to the chart dir of some dev/ release branch
   push:
     # prevent unnecessary GH action runs for files outside of charts folder

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -24,11 +24,11 @@ on:
   push:
     branches: 
      - main
-     - 'releases/**'
+     - 'release/*'
   pull_request:
     branches: 
       - main
-      - 'releases/**'
+      - 'release/*'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## WHAT

This PR fixes the build workflow trigger declarations. The `tags` have previously been defined for `workflow_dispatch`, but this event type does not take other arguments than `input`. See [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)

## WHY

Creating a git tag in the `release/1.9.8` branch did not trigger any builds. The new declaration should fix that

## FURTHER NOTES

`v1.9.8` tag was deleted again. When the changes are merged, we should be able to just re-create it
