### PR TITLE
chore: trigger build/helm and kics on 'release' branch prefix not 're…leases'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     # Can be scheduled on all branches and version tags
     tags:
       - 'v*.*.*'
@@ -34,7 +34,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths-ignore:
       - 'charts/**'
       - 'docs/**'

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -25,14 +25,14 @@ on:
   push:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths:
       - .github/workflows/**
       - charts/**
   pull_request:
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
     paths:
       - .github/workflows/**
       - charts/**

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -29,7 +29,7 @@ on:
       - 'charts/**'
     branches:
       - main
-      - 'releases/**'
+      - 'release/*'
 
 jobs:
   release:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -24,11 +24,11 @@ on:
   push:
     branches: 
      - main
-     - 'releases/**'
+     - 'release/*'
   pull_request:
     branches: 
       - main
-      - 'releases/**'
+      - 'release/*'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## WHAT

Fixes four workflows

## WHY

Workflows did not trigger on release branch

## FURTHER NOTES
