### PR TITLE
fix(chart-lint): Use the event branch as the linting and change reference

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -76,12 +76,12 @@ jobs:
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --target-branch ${{ github.event.ref }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${{ github.event.ref }})
           if [[ -n "$changed" ]]; then
             echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
## WHAT

use the event branch instead of the repository default branch in chart linting and testuing.

## WHY

chart liniting fails on release branches when comparing against a version-higher main.

## FURTHER NOTES

