### PR TITLE
fix(chart-lint): should work on push and pull requests

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -52,9 +52,21 @@ on:
         required: false
         type: string
 
+  git-branch:
+    name: Determine target branch
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.git-branch.outputs.BRANCH }}
+    steps:
+      - name: Resolve git branch
+        id: git-branch
+        run: |
+          echo "BRANCH=$(echo $GITHUB_REF | sed -e "s#refs/(heads|tags)/##g")" >> $GITHUB_OUTPUT
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    needs: [ git-branch ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -76,12 +88,12 @@ jobs:
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.ref }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --target-branch ${{ needs.git-branch.outputs.value }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.ref }})
+          changed=$(ct list-changed --target-branch ${{ needs.git-branch.outputs.value }}
           if [[ -n "$changed" ]]; then
             echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -52,6 +52,7 @@ on:
         required: false
         type: string
 
+jobs:
   git-branch:
     name: Determine target branch
     runs-on: ubuntu-latest
@@ -63,7 +64,6 @@ on:
         run: |
           echo "BRANCH=$(echo $GITHUB_REF | sed -e "s#refs/(heads|tags)/##g")" >> $GITHUB_OUTPUT
 
-jobs:
   lint-test:
     runs-on: ubuntu-latest
     needs: [ git-branch ]

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -53,20 +53,8 @@ on:
         type: string
 
 jobs:
-  git-branch:
-    name: Determine target branch
-    runs-on: ubuntu-latest
-    outputs:
-      value: ${{ steps.git-branch.outputs.BRANCH }}
-    steps:
-      - name: Resolve git branch
-        id: git-branch
-        run: |
-          echo "BRANCH=$(echo $GITHUB_REF | sed -e "s#refs/(heads|tags)/##g")" >> $GITHUB_OUTPUT
-
   lint-test:
     runs-on: ubuntu-latest
-    needs: [ git-branch ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -88,12 +76,12 @@ jobs:
         uses: helm/chart-testing-action@v2.3.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ needs.git-branch.outputs.value }} --config charts/config/chart-testing-config.yaml
+        run: ct lint --target-branch ${{ github.base_ref || github.ref_name }} --config charts/config/chart-testing-config.yaml
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ needs.git-branch.outputs.value }}
+          changed=$(ct list-changed --target-branch ${{ github.base_ref || github.ref_name }})
           if [[ -n "$changed" ]]; then
             echo "CHART_CHANGED=true" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
## WHAT

see title. last try to fix this shit.

## WHY

github.event.ref is empty on push

## FURTHER NOTES

see https://stackoverflow.com/questions/62779643/how-to-extract-branch-name-on-delete-event-github-actions
