### PR TITLE
chore|fix(remoting): Enhance manual build trigger and fix docker glitches due to migrating from maven to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2023 T-Systems International GmbH
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
@@ -41,6 +42,17 @@ on:
       - '**/*.md'
   # Manual workflow trigger
   workflow_dispatch:
+    inputs:
+      deploy_maven:
+        description: 'whether maven packages should be deployed (default: false)'
+        default: 'false'
+        required: false
+        type: string
+      deploy_docker:
+        description: 'whether docker images should be deployed (default: true)'
+        default: 'true'
+        required: false
+        type: string
 
 # If build is triggered several times, e.g., through subsequent pushes
 # into the same PR, cancel the previous runs, see below
@@ -59,12 +71,18 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+
       # Determine the right target docker repo
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
+            echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+            echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
           exit 0
 
       # Get the Code
@@ -76,19 +94,19 @@ jobs:
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enable deployment access (on main branch and version tags only)
+      # Enable deployment access (on demand or main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
-      
-      # Run Maven Deploy (if either running on main or a version tag)
+
+      # Run Maven Deploy (on demand or if either running on main or a version tag)
       - name: Deploy Java via Maven
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_maven == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           ./mvnw -s settings.xml deploy -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
         env:
@@ -97,7 +115,7 @@ jobs:
 
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
-        if: ${{ ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.event.inputs.deploy_maven != 'true' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') ) }}
         run: |
           ./mvnw -s settings.xml install
         env:
@@ -119,7 +137,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
@@ -129,13 +147,13 @@ jobs:
           context: conforming/.
           file: conforming/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-conf.outputs.tags }}
           labels: ${{ steps.meta-conf.outputs.labels }}
 
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Conforming Agent
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
+        if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: conforming/README.md
@@ -158,7 +176,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
@@ -168,13 +186,13 @@ jobs:
           context: remoting/.
           file: remoting/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-remote.outputs.tags }}
           labels: ${{ steps.meta-remote.outputs.labels }}
 
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Remoting Agent
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
+        if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: remoting/README.md
@@ -197,7 +215,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.2-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
@@ -207,13 +225,13 @@ jobs:
           context: provisioning/.
           file: provisioning/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ ( github.event.inputs.deploy_docker == 'true' || github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
           tags: ${{ steps.meta-prov.outputs.tags }}
           labels: ${{ steps.meta-prov.outputs.labels }}
 
       # Important step to push image description to DockerHub - since this is version independent, we always take it from main
       - name: Update Docker Hub description for Provisioning Agent
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && github.ref == 'refs/heads/main' }}
+        if: ${{ steps.set-docker-repo.outputs.REPO == 'docker.io' && github.ref == 'refs/heads/main' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: provisioning/README.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,6 @@ on:
   # Manual workflow trigger
   workflow_dispatch:
 
-# the docker registry and namespace
-env:
-  IMAGE_NAMESPACE: "tractusx"
-
 # If build is triggered several times, e.g., through subsequent pushes
 # into the same PR, cancel the previous runs, see below
 concurrency:
@@ -63,6 +59,14 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      # Determine the right target docker repo
+      - name: Check github repository and set docker repo
+        id: set-docker-repo
+        run: |
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          exit 0
+
       # Get the Code
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -72,27 +76,28 @@ jobs:
       # Setup build environment
       - uses: ./.github/actions/setup-java
 
-      # Enabled deployment access (if either running on main or a version tag on eclipse-tractusx)
+      # Enable deployment access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
+          registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      # Run Maven Deploy (if either running on main or a version tag on eclipse-tractusx)
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
+      
+      # Run Maven Deploy (if either running on main or a version tag)
       - name: Deploy Java via Maven
-        if: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          ./mvnw -s settings.xml deploy
+          ./mvnw -s settings.xml deploy -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Run Maven Install (otherwise)
       - name: Build Java via Maven
-        if: ${{ github.repository != 'eclipse-tractusx/knowledge-agents' || (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')) }}
         run: |
           ./mvnw -s settings.xml install
         env:
@@ -105,7 +110,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.IMAGE_NAMESPACE }}/conforming-agent
+            ${{ steps.set-docker-repo.outputs.REPO }}/conforming-agent
           # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
@@ -124,7 +129,7 @@ jobs:
           context: conforming/.
           file: conforming/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta-conf.outputs.tags }}
           labels: ${{ steps.meta-conf.outputs.labels }}
 
@@ -134,9 +139,9 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: conforming/README.md
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/conforming-agent
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
+          repository: ${{ steps.set-docker-repo.outputs.REPO }}/conforming-agent
 
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker Meta Remoting
@@ -144,7 +149,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.IMAGE_NAMESPACE }}/remoting-agent
+            ${{ steps.set-docker-repo.outputs.REPO }}/remoting-agent
           # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
@@ -163,7 +168,7 @@ jobs:
           context: remoting/.
           file: remoting/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta-remote.outputs.tags }}
           labels: ${{ steps.meta-remote.outputs.labels }}
 
@@ -173,9 +178,9 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: remoting/README.md
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/remoting-agent
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
+          repository: ${{ steps.set-docker-repo.outputs.REPO }}/remoting-agent
 
       # Create SemVer or ref tags dependent of trigger event
       - name: Docker Meta Provisioning
@@ -183,7 +188,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.IMAGE_NAMESPACE }}/provisioning-agent
+            ${{ steps.set-docker-repo.outputs.REPO }}/provisioning-agent
           # Automatically prepare image tags; See action docs for more examples.
           # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
@@ -202,7 +207,7 @@ jobs:
           context: provisioning/.
           file: provisioning/src/main/docker/Dockerfile
           # Build image for verification purposes on every trigger event. Only push if event is not a PR
-          push: ${{ github.repository == 'eclipse-tractusx/knowledge-agents'  && (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+          push: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
           tags: ${{ steps.meta-prov.outputs.tags }}
           labels: ${{ steps.meta-prov.outputs.labels }}
 
@@ -212,7 +217,6 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           readme-filepath: provisioning/README.md
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/provisioning-agent
-
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
+          repository: ${{ steps.set-docker-repo.outputs.REPO }}/provisioning-agent

--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 #
@@ -98,7 +99,7 @@ jobs:
 
       - name: Build Java/Docker via Maven
         run: |
-          ./mvnw -s settings.xml deploy -Drepo=kind-registry:5000/tractusx/ -Dmaven.deploy.skip -DskipTests -Pwith-docker-image 
+          ./mvnw -s settings.xml deploy -Drepo=kind-registry:5000/tractusx/ -Dmaven.deploy.skip -DskipTests -Pwith-docker-image
         if: github.event_name != 'pull_request' || env.CHART_CHANGED == 'true'
 
       # install the chart to the kind cluster and run helm test
@@ -119,7 +120,7 @@ jobs:
 
       # Upgrade the released chart version with the locally available chart
       # default value for event_name != workflow_dispatch
-      - name: Run helm upgrade on provisioning agent 
+      - name: Run helm upgrade on provisioning agent
         run: |
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
           helm install provisioning tractusx-dev/provisioning-agent --version ${{ github.event.inputs.upgrade_from }} --set=image.registry=kind-registry:5000/

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 #

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,16 +18,15 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "KICS"
 
 on:
   push:
-    branches: 
-     - main
-     - 'release/*'
+    branches:
+      - main
+      - 'release/*'
   pull_request:
-    branches: 
+    branches:
       - main
       - 'release/*'
 
@@ -48,22 +48,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-#
-# Take out 
-#   - the "Always" Image Pull Policy Rule (caa3479d-885d-4882-9aac-95e5e78ef5c2) because depending on the deployment/rollout scenarios, other policies are more reasonable.
-#   - the "LimitRange" Namespace Rule (4a20ebac-1060-4c81-95d1-1f7f620e983b) because the target namespace may define that external to the Chart.
-#   - the "ResourceQuota" Namespace Rule (48a5beba-e4c0-4584-a2aa-e6894e4cf424) because the target namespace may define that external to the Chart.
-#   - the "Digest" Image Requirement (7c81d34c-8e5a-402b-9798-9f442630e678) can be realised for releases, but not the mainline
-#   - the "AppArmorProfile" Requirement (8b36775e-183d-4d46-b0f7-96a6f34a723f) is still a beta functionality
-#   - the "Administrative Boundaries" Info (e84eaf4d-2f45-47b2-abe8-e581b06deb66) would not be visible
-#
+      #
+      # Take out
+      #   - the "Always" Image Pull Policy Rule (caa3479d-885d-4882-9aac-95e5e78ef5c2) because depending on the deployment/rollout scenarios, other policies are more reasonable.
+      #   - the "LimitRange" Namespace Rule (4a20ebac-1060-4c81-95d1-1f7f620e983b) because the target namespace may define that external to the Chart.
+      #   - the "ResourceQuota" Namespace Rule (48a5beba-e4c0-4584-a2aa-e6894e4cf424) because the target namespace may define that external to the Chart.
+      #   - the "Digest" Image Requirement (7c81d34c-8e5a-402b-9798-9f442630e678) can be realised for releases, but not the mainline
+      #   - the "AppArmorProfile" Requirement (8b36775e-183d-4d46-b0f7-96a6f34a723f) is still a beta functionality
+      #   - the "Administrative Boundaries" Info (e84eaf4d-2f45-47b2-abe8-e581b06deb66) would not be visible
+      #
       - name: KICS scan
         uses: checkmarx/kics-github-action@v1.7.0
         with:
           path: "."
           fail_on: high
           disable_secrets: true
-          output_path: kicsResults/          
+          output_path: kicsResults/
           exclude_queries: caa3479d-885d-4882-9aac-95e5e78ef5c2,4a20ebac-1060-4c81-95d1-1f7f620e983b,48a5beba-e4c0-4584-a2aa-e6894e4cf424,7c81d34c-8e5a-402b-9798-9f442630e678,8b36775e-183d-4d46-b0f7-96a6f34a723f,e84eaf4d-2f45-47b2-abe8-e581b06deb66
           output_formats: "json,sarif"
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -85,21 +85,31 @@ jobs:
           - remoting-agent
           - conforming-agent
     steps:
+      # Determine the right target docker repo
+      - name: Check github repository and set docker repo
+        id: set-docker-repo
+        run: |
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
+          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          exit 0
+
       - uses: actions/checkout@v3.5.2
 
-      # We need to login
+      # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/login-action@v2
         with:
+          registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
           # Use existing DockerHub credentials present as secrets
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
         ## This step will fail if the docker images is not found
       - name: "Check if image exists"
         id: imageCheck
         run: |
-          docker manifest inspect tractusx/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
+          docker manifest inspect ${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}
         continue-on-error: true
 
         ## the next two steps will only execute if the image exists check was successful
@@ -107,7 +117,7 @@ jobs:
         if: success() && steps.imageCheck.outcome != 'failure'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "tractusx/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
+          image-ref: "${{ steps.set-docker-repo.outputs.REPO }}/${{ matrix.image }}:${{ needs.git-sha7.outputs.value }}"
           format: "sarif"
           output: "trivy-results-${{ matrix.image }}.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "Trivy"
 
 on:
@@ -25,7 +25,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
   workflow_run:
-    workflows: [ "Build" ]
+    workflows: ["Build"]
     branches:
       - main
     tags:
@@ -71,33 +71,40 @@ jobs:
           sarif_file: "trivy-results-config.sarif"
 
   trivy:
-    needs: [ git-sha7 ]
+    needs: [git-sha7]
     permissions:
       actions: read
       contents: read
       security-events: write
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # continue scanning other images although if the other has been vulnerable
+      # continue scanning other images although if the other has been vulnerable
+      fail-fast: false
       matrix:
         image:
           - provisioning-agent
           - remoting-agent
           - conforming-agent
     steps:
+
       # Determine the right target docker repo
       - name: Check github repository and set docker repo
         id: set-docker-repo
         run: |
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT; else echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT;  fi          
-          if [ "${{ github.repository }}" == "eclipse-tractusx/knowledge-agents" ]; then echo "REPO=tractusx" >> $GITHUB_OUTPUT; else echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT;  fi
+          echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
+          echo "REPO=tractusx" >> $GITHUB_OUTPUT;
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          then
+            echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
+            echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          fi
           exit 0
 
       - uses: actions/checkout@v3.5.2
 
       # Enable repository access (on main branch and version tags only)
       - name: Login to GitHub Container Registry
-        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ ( github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/v') ) }}
         uses: docker/login-action@v2
         with:
           registry: ${{ steps.set-docker-repo.outputs.REGISTRY }}
@@ -105,7 +112,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER || github.actor }}
           password: ${{ secrets.DOCKER_HUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-        ## This step will fail if the docker images is not found
+      # This step will fail if the docker images is not found
       - name: "Check if image exists"
         id: imageCheck
         run: |

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -1,3 +1,4 @@
+---
 #
 #  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 #
@@ -17,7 +18,6 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
----
 name: "Veracode"
 
 on:
@@ -49,20 +49,19 @@ jobs:
       - name: Verify proper formatting
         run: ./mvnw spotless:check
 
-###
-# Standalone applications have all dependencies in their jar
-###
+  ###
+  # Standalone applications have all dependencies in their jar
+  ###
   build_standalone:
     runs-on: ubuntu-latest
-    needs: [ secret-presence, verify-formatting ]
+    needs: [secret-presence, verify-formatting]
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        variant: [ { dir: remoting, name: remoting-agent },
-                   { dir: conforming, name: conforming-agent }
-                  ]
+        variant: [{dir: remoting, name: remoting-agent},
+                  {dir: conforming, name: conforming-agent}]
     steps:
       # Set-Up
       - uses: actions/checkout@v3.5.2
@@ -90,23 +89,22 @@ jobs:
           vid: ${{ secrets.ORG_VERACODE_API_ID }}
           vkey: ${{ secrets.ORG_VERACODE_API_KEY }}
 
-###
-# Embedded applications need dependencies being provided.
-# Expecially wrt. Spring 5.3.28 Web there is an open HIGH vulnerability regarding
-# org/springframework/remoting/httpinvoker which will not be fixed
-# so we manipulate the jar in the docker environment directly and exclude
-# the dependency from the scan
-###
+  ###
+  # Embedded applications need dependencies being provided.
+  # Expecially wrt. Spring 5.3.28 Web there is an open HIGH vulnerability regarding
+  # org/springframework/remoting/httpinvoker which will not be fixed
+  # so we manipulate the jar in the docker environment directly and exclude
+  # the dependency from the scan
+  ###
   build_embedded:
     runs-on: ubuntu-latest
-    needs: [ secret-presence, verify-formatting ]
+    needs: [secret-presence, verify-formatting]
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        variant: [ { dir: provisioning, name: provisioning-agent },
-        ]
+        variant: [{dir: provisioning, name: provisioning-agent}]
     steps:
       # Set-Up
       - uses: actions/checkout@v3.5.2

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -295,6 +295,13 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/META-INF/services</directory>
+                <includes>
+                    <include>org.eclipse.rdf4j.sail.config.SailFactory</include>
+                </includes>
+                <targetPath>META-INF/services</targetPath>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/remoting/src/main/docker/Dockerfile
+++ b/remoting/src/main/docker/Dockerfile
@@ -21,7 +21,7 @@
 
 FROM openjdk:22-jdk-slim AS build
 
-COPY target/original-remoting-agent-*-SNAPSHOT.jar /opt/lib/
+COPY target/original-remoting-agent-*.jar /opt/lib/
 COPY target/lib/guava-*.jar /opt/lib/
 COPY target/lib/netty-*.jar /opt/lib/
 COPY target/lib/jetty-*.jar /opt/lib/


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Manual triggering of the build workflow now comes with deployment options for maven and docker.
Docker setup of remoting agent has been debugged.
Also a yamllint check was done on the workflows.

## WHY

When migrating from a maven to a github-action-based docker build based on release branches and tags, two glitches at the docker artifacts (not the maven artifacts) have been introduced. This PR solves the glitches as well as the opportunity to fix them in all future releases.

## FURTHER NOTES

Closes #44 <-- _insert Issue number if one exists_
