### PR TITLE
PRIO-1 fix(workflows): correct copy&paste error from sibling repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
           echo "REPO=tractusx" >> $GITHUB_OUTPUT;
-          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents" ];
           then
             echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
             echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo "REGISTRY=docker.io" >> $GITHUB_OUTPUT;
           echo "REPO=tractusx" >> $GITHUB_OUTPUT;
-          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents-edc" ];
+          if [ "${{ github.repository }}" != "eclipse-tractusx/knowledge-agents" ];
           then
             echo "REGISTRY=ghcr.io" >> $GITHUB_OUTPUT
             echo "REPO=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Correcty two repository name references which were copied from workflows of a sibling repository.

## WHY

build and trivy would not run correctly.

## FURTHER NOTES

No manuel intervention after merge necessary.
see https://github.com/eclipse-tractusx/knowledge-agents/actions/runs/6467024646
