### PR TITLE
chore: prepare release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.15-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.15,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
@@ -176,7 +176,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.15-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.15,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings
@@ -215,7 +215,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=1.10.15-SNAPSHOT,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.10.15,enable=${{ github.event.inputs.deploy_docker == 'true' || github.ref == format('refs/heads/{0}', 'main') }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # build in any case, but push only main and version tag settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ All notable changes to this product will be documented in this file.
 
 # Released
 
+## [1.10.15] - 2023-11-28
+
+### Added
+
+- Provisioning Agent (chart): Enable Integrated H2 Database Sample by correct user und group ids
+
+### Changed
+
+- Provisioning Agent: Upgrade to Ontop 5.1.0
+- Codestyle consistent with Tractus-X using checkstyle
+- Remoting Agent: Debug the test/sample repository descriptions
+
+### Removed
+
+- Cyclone DX Boms (we have dash)
+
 ## [1.9.8] - 2023-09-04
 
 ### Added

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -67,7 +67,7 @@ maven/mavencentral/io.swagger.core.v3/swagger-core/2.2.12, Apache-2.0, approved,
 maven/mavencentral/io.swagger.core.v3/swagger-integration/2.2.12, Apache-2.0, approved, #10352
 maven/mavencentral/io.swagger.core.v3/swagger-jaxrs2/2.2.12, Apache-2.0, approved, #9814
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.2.12, Apache-2.0, approved, #10353
-maven/mavencentral/it.unibz.inf.ontop/ontop-model/5.1.0, Apache-2.0 AND OGC-1.0, restricted, #11624
+maven/mavencentral/it.unibz.inf.ontop/ontop-model/5.1.0, Apache-2.0, approved, #11624
 maven/mavencentral/it.unibz.inf.ontop/ontop-obda-core/5.1.0, Apache-2.0, approved, #11623
 maven/mavencentral/it.unibz.inf.ontop/ontop-rdb/5.1.0, Apache-2.0, approved, #11626
 maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf

--- a/charts/conforming-agent/Chart.yaml
+++ b/charts/conforming-agent/Chart.yaml
@@ -28,7 +28,7 @@ home: https://github.com/eclipse-tractusx/knowledge-agents/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents/tree/main/conforming
 type: application
-appVersion: "1.10.15-SNAPSHOT"
-version: 1.10.15-SNAPSHOT
+appVersion: "1.10.15"
+version: 1.10.15
 maintainers:
   - name: 'Tractus-X Knowledge Agents Team'

--- a/charts/conforming-agent/README.md
+++ b/charts/conforming-agent/README.md
@@ -20,7 +20,7 @@
 
 # conforming-agent
 
-![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for the Tractus-X Conforming Agent which is a container to assess the conformity of all other parts of the Agent-Enabled Dataspace.
 
@@ -31,7 +31,7 @@ This chart has no prerequisites.
 ## TL;DR
 ```shell
 $ helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-$ helm install my-release eclipse-tractusx/conforming-agent --version 1.10.15-SNAPSHOT
+$ helm install my-release eclipse-tractusx/conforming-agent --version 1.10.15
 ```
 
 ## Maintainers

--- a/charts/provisioning-agent/Chart.yaml
+++ b/charts/provisioning-agent/Chart.yaml
@@ -28,7 +28,7 @@ home: https://github.com/eclipse-tractusx/knowledge-agents/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents/tree/main/provisioning
 type: application
-appVersion: "1.10.15-SNAPSHOT"
-version: 1.10.15-SNAPSHOT
+appVersion: "1.10.15"
+version: 1.10.15
 maintainers:
   - name: 'Tractus-X Knowledge Agents Team'

--- a/charts/provisioning-agent/README.md
+++ b/charts/provisioning-agent/README.md
@@ -20,7 +20,7 @@
 
 # provisioning-agent
 
-![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for the Tractus-X Provisioning Agent which is a container to Bridge Agent-Enabled Connector and Relational Data Sources.
 
@@ -31,7 +31,7 @@ This chart has no prerequisites.
 ## TL;DR
 ```shell
 $ helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-$ helm install my-release eclipse-tractusx/provisioning-agent --version 1.10.15-SNAPSHOT
+$ helm install my-release eclipse-tractusx/provisioning-agent --version 1.10.15
 ```
 
 ## Maintainers

--- a/charts/remoting-agent/Chart.yaml
+++ b/charts/remoting-agent/Chart.yaml
@@ -28,7 +28,7 @@ home: https://github.com/eclipse-tractusx/knowledge-agents/
 sources:
   - https://github.com/eclipse-tractusx/knowledge-agents/tree/main/remoting
 type: application
-appVersion: "1.10.15-SNAPSHOT"
-version: 1.10.15-SNAPSHOT
+appVersion: "1.10.15"
+version: 1.10.15
 maintainers:
   - name: 'Tractus-X Knowledge Agents Team'

--- a/charts/remoting-agent/README.md
+++ b/charts/remoting-agent/README.md
@@ -19,7 +19,7 @@
 -->
 # remoting-agent
 
-![Version: 1.10.15-SNAPSHOT](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
+![Version: 1.10.15](https://img.shields.io/badge/Version-1.10.2--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.15](https://img.shields.io/badge/AppVersion-1.10.2--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for the Tractus-X Remoting Agent which is a container to Bridge Agent-Enabled Connector and REST APIs.
 
@@ -30,7 +30,7 @@ This chart has no prerequisites.
 ## TL;DR
 ```shell
 $ helm repo add eclipse-tractusx https://eclipse-tractusx.github.io/charts/dev
-$ helm install my-release eclipse-tractusx/remoting-agent --version 1.10.15-SNAPSHOT
+$ helm install my-release eclipse-tractusx/remoting-agent --version 1.10.15
 ```
 
 ## Maintainers

--- a/conforming/README.md
+++ b/conforming/README.md
@@ -53,15 +53,15 @@ mvn package
 ```
 
 This will generate 
-- a [plugin jar](target/original-conforming-agent-1.10.15-SNAPSHOT.jar) containing all necessary components to be dropped into a Jakarta-Compatible Web Server.
-- a [standalone jar](target/conforming-agent-1.10.15-SNAPSHOT.jar) including the Jakarta-Reference Implementation (Glassfish).
+- a [plugin jar](target/original-conforming-agent-1.10.15.jar) containing all necessary components to be dropped into a Jakarta-Compatible Web Server.
+- a [standalone jar](target/conforming-agent-1.10.15.jar) including the Jakarta-Reference Implementation (Glassfish).
 
 ### Run Locally
 
-The [standalone jar](target/conforming-agent-1.10.15-SNAPSHOT.jar) may be started as follows
+The [standalone jar](target/conforming-agent-1.10.15.jar) may be started as follows
 
 ```console
-java -cp target/conforming-agent-1.10.15-SNAPSHOT.jar org.eclipse.tractusx.agents.conforming.Bootstrap"
+java -cp target/conforming-agent-1.10.15.jar org.eclipse.tractusx.agents.conforming.Bootstrap"
 ```
 
 ### Containerizing
@@ -75,7 +75,7 @@ mvn install -Pwith-docker-image
 or invoke the following docker command after a successful package run
 
 ```console
-docker build -t tractusx/conforming-agent:1.10.15-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/conforming-agent:1.10.15 -f src/main/docker/Dockerfile .
 ```
 
 This will create a docker image based on a minimal java environment for running the Glassfish-based standalone jar.
@@ -84,7 +84,7 @@ To run the docker image, you could invoke this command
 
 ```console
 docker run -p 8080:8080 \
-  tractusx/conforming-agent:1.10.15-SNAPSHOT
+  tractusx/conforming-agent:1.10.15
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8080/) via
@@ -141,7 +141,7 @@ It can be added to your umbrella chart.yaml by the following snippet
 dependencies:
   - name: conforming-agent
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.10.15-SNAPSHOT
+    version: 1.10.15
     alias: my-conforming-agent
 ```
 

--- a/conforming/pom.xml
+++ b/conforming/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>agents</artifactId>
-        <version>1.10.15-SNAPSHOT</version>
+        <version>1.10.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx</groupId>
     <artifactId>agents</artifactId>
-    <version>1.10.15-SNAPSHOT</version>
+    <version>1.10.15</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents Reference Implementations</name>
     <description>Provides Reference Implementations and Artifacts to Realize Semantic Dataspace Backends</description>

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -111,7 +111,7 @@ mvn package
 ```
 
 This will generate
-- a [pluging jar](target/provisioning-agent-1.10.15-SNAPSHOT.jar) which maybe dropped into an Ontop server (into the lib folder)
+- a [pluging jar](target/provisioning-agent-1.10.15.jar) which maybe dropped into an Ontop server (into the lib folder)
 
 ### Containerizing (Provisioning Agent)
 
@@ -124,7 +124,7 @@ mvn install -Pwith-docker-image
 or invoke the following docker command after a successful package run
 
 ```console
-docker build -t tractusx/provisioning-agent:1.10.15-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/provisioning-agent:1.10.15 -f src/main/docker/Dockerfile .
 ```
 
 The image contains
@@ -144,7 +144,7 @@ docker run -p 8080:8080 \
   -v $(pwd)/resources/university-role1.obda:/input/mapping.obda \
   -v $(pwd)/resources/university-role1.properties:/input/settings.properties \
   -v $(pwd)/resources/university.sql:/tmp/university.sql \
-  tractusx/provisioning-agent:1.10.15-SNAPSHOT
+  tractusx/provisioning-agent:1.10.15
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8080/) via
@@ -192,7 +192,7 @@ docker run -p 8080:8080 -p 8082:8082 \
   -e ONTOP_MAPPING_FILE="/input/role1.obda /input/role2.obda" \
   -e ONTOP_PROPERTIES_FILE="/input/role1.properties /input/role2.properties" \
   -e ONTOP_DEV_MODE="false false" \
-  tractusx/provisioning-agent:1.10.15-SNAPSHOT
+  tractusx/provisioning-agent:1.10.15
 ````
 
 Accessing entities spanning two schemas using the first role/endpoint delivers a greater count
@@ -296,7 +296,7 @@ It can be added to your umbrella chart.yaml by the following snippet
 dependencies:
   - name: provisioning-agent
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.10.15-SNAPSHOT
+    version: 1.10.15
     alias: my-provider-agent
 ```
 

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>agents</artifactId>
-        <version>1.10.15-SNAPSHOT</version>
+        <version>1.10.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/provisioning/src/main/docker/Dockerfile
+++ b/provisioning/src/main/docker/Dockerfile
@@ -56,11 +56,16 @@ RUN if [ "${HTTP_PROXY}" != ""  ]; then \
         echo "Acquire::http::Proxy \"${HTTP_PROXY}\"" >> /etc/apt/apt.conf.d/proxy.conf; \
         echo "Acquire::https::Proxy \"${HTTP_PROXY}\"" >> /etc/apt/apt.conf.d/proxy.conf; \
     fi && \
+    apt-get -y upgrade && \
+    apt-get -y update && \
+    apt-get -y install libc6=2.35-0ubuntu3.4 && \
+    apt-get -y install libc-bin=2.35-0ubuntu3.4 && \
     rm /opt/ontop/lib/guava-*.jar && \
     rm /opt/ontop/lib/tomcat-embed-*.jar && \
     rm /opt/ontop/lib/spring-*.jar && \
     mkdir -p /opt/ontop/jdbc && \
     for jdbcDriver in "$jdbcDrivers"; do wget --no-check-certificate -q -P /opt/ontop/jdbc ${jdbcDriver} ; done && \
+    apt-get -y --auto-remove remove wget && \
     if [ "${HTTP_PROXY}" != ""  ]; then rm -f /etc/apt/apt.conf.d/proxy.conf; fi && \
     mkdir -p /opt/ontop/input && \
     mkdir -p /opt/ontop/database && \

--- a/remoting/README.md
+++ b/remoting/README.md
@@ -134,15 +134,15 @@ mvn package
 ```
 
 This will generate 
-- a [standalone jar](target/remoting-agent-1.10.15-SNAPSHOT.jar) containing all necessary rdf4j components to build your own repository server.
-- a [pluging jar](target/original-remoting-agent-1.10.15-SNAPSHOT.jar) which maybe dropped into an rdf4j server for remoting support.
+- a [standalone jar](target/remoting-agent-1.10.15.jar) containing all necessary rdf4j components to build your own repository server.
+- a [pluging jar](target/original-remoting-agent-1.10.15.jar) which maybe dropped into an rdf4j server for remoting support.
 
 ### Run Locally
 
-The standalone jar](target/remoting-agent-1.10.15-SNAPSHOT.jar) contains an example application that runs a sample repository against a sample source
+The standalone jar](target/remoting-agent-1.10.15.jar) contains an example application that runs a sample repository against a sample source
 
 ```console
-java -jar target/remoting-agent-1.10.15-SNAPSHOT.jar -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
+java -jar target/remoting-agent-1.10.15.jar -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
 ```
 
 ### Containerizing
@@ -156,7 +156,7 @@ mvn install -Pwith-docker-image
 or invoke the following docker command after a successful package run
 
 ```console
-docker build -t tractusx/remoting-agent:1.10.15-SNAPSHOT -f src/main/docker/Dockerfile .
+docker build -t tractusx/remoting-agent:1.10.15 -f src/main/docker/Dockerfile .
 ```
 
 This will create a docker image including an extended rdf4j-server as well as an interactive rdf4j-workbench.
@@ -166,7 +166,7 @@ To run the docker image, you could invoke this command
 ```console
 docker run -p 8081:8081 \
   -v $(pwd)/src/test:/var/rdf4j/config \
-  tractusx/remoting-agent:1.10.15-SNAPSHOT
+  tractusx/remoting-agent:1.10.15
 ````
 
 Afterwards, you should be able to access the [local SparQL endpoint](http://localhost:8081/) via
@@ -223,7 +223,7 @@ It can be added to your umbrella chart.yaml by the following snippet
 dependencies:
   - name: remoting-agent
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.10.15-SNAPSHOT
+    version: 1.10.15
     alias: my-remoting-agent
 ```
 

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.tractusx</groupId>
         <artifactId>agents</artifactId>
-        <version>1.10.15-SNAPSHOT</version>
+        <version>1.10.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/remoting/src/main/docker/Dockerfile
+++ b/remoting/src/main/docker/Dockerfile
@@ -92,6 +92,7 @@ RUN	mkdir -p /var/rdf4j/server/conf && \
     rm /usr/local/tomcat/conf/web.xml && \
     chown -R tomcat:tomcat /var/rdf4j /usr/local/tomcat && \
     apt-get -y --auto-remove remove unzip && \
+    apt-get -y --auto-remove remove wget && \
 	chmod 775 /usr/local/tomcat /usr/local/tomcat/bin /usr/local/tomcat/bin/catalina.sh /var/rdf4j/server 
 
 COPY --from=build /opt/lib/*.jar /usr/local/tomcat/webapps/rdf4j-server/WEB-INF/lib/

--- a/upgrade_version.sh
+++ b/upgrade_version.sh
@@ -16,7 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OLD_VERSION=1.10.15-SNAPSHOT
+OLD_VERSION=1.10.15
 echo Upgrading from $OLD_VERSION to $1
 PATTERN=s/$OLD_VERSION/$1/g
 LC_ALL=C


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

remove -SNAPSHOT suffix from versions before tagging the release. extend changelog.

## WHY

release will have no -SNAPSHOT suffix.
DEPENDENCIES need be updated

## FURTHER NOTES

One dependency/IP check is still open before this can be merged and tagged.
https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/11624

