### PR TITLE
chore: need to (re-)enable spotless for veracode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,21 @@
                     <version>2.4</version>
                 </plugin>
                 <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.37.0</version>
+                    <executions>
+                        <execution>
+                            <id>format</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>check</goal>
+                                <goal>apply</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.3.0</version>


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Reintroduce the spotless plugin definition.

## WHY

When introducing checkstyle, the spotless plugin had been replaced/disabled.
Spotless check is part of the veracode workflow.

see https://github.com/eclipse-tractusx/knowledge-agents/actions/runs/6952127226

## FURTHER NOTES

Could you please invoke https://github.com/eclipse-tractusx/knowledge-agents/actions/workflows/veracode.yml afterwards.


