### PR TITLE
fix: Provisioning Agent Ontology Configuration & JRW Compatibility with Dremio Drivers

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -88,7 +88,7 @@ jobs:
 
       # Preparing a kind cluster to install and test charts on
       - name: Create kind cluster
-        uses: container-tools/kind-action@61f1afd4807b0dac84f3232ec99e45c63701d220 # v2.0.1
+        uses: container-tools/kind-action@0fc957b58d9a5bc9ca57a1b419324a2074c7653b # v2.0.3
         with:
           # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
           version: v0.20.0

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -42,7 +42,7 @@ jobs:
   verify-formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-java
@@ -118,7 +118,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tar gzip files for veracode upload
         run: |-
-          tar --exclude='spring-web-5.3.28.jar' -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/lib/*.jar ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
+          tar --exclude='spring-web-5.3.31.jar' -czvf ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}.tar.gz ${{ matrix.variant.dir }}/target/lib/*.jar ${{ matrix.variant.dir }}/target/${{ matrix.variant.name }}-*.jar
       - name: Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@c3c0b78bddb42d5f6b10d70562f692215a410d7b #v1.0
         if: |

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,8 +1,6 @@
 maven/mavencentral/aopalliance/aopalliance/1.0, LicenseRef-Public-Domain, approved, CQ2918
-maven/mavencentral/ch.qos.logback/logback-classic/1.2.12, EPL-1.0, approved, CQ13636
 maven/mavencentral/ch.qos.logback/logback-classic/1.2.13, EPL-1.0, approved, CQ13636
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.12, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.2.12, EPL-1.0, approved, CQ13635
 maven/mavencentral/ch.qos.logback/logback-core/1.2.13, EPL-1.0, approved, CQ13635
 maven/mavencentral/ch.qos.logback/logback-core/1.4.12, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.13.5, Apache-2.0, approved, clearlydefined

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -278,7 +278,7 @@ Eclipse Tractus-X product(s) installed within the image:
 
 **Used base image**
 
-- [eclipse-temurin:21-jre-alpine](https://github.com/adoptium/containers)
+- [eclipse-temurin:11-jre-alpine](https://github.com/adoptium/containers)
 - Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
 - Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
 - Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin

--- a/provisioning/pom.xml
+++ b/provisioning/pom.xml
@@ -102,6 +102,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-actuator</artifactId>
             <version>${spring.boot.version}</version>

--- a/provisioning/resources/entrypoint.sh
+++ b/provisioning/resources/entrypoint.sh
@@ -122,7 +122,7 @@ for ENDPOINT in $ONTOP_PORT ; do  # NOTE: do not double-quote $services here.
   else 
     echo "Invoking intermediate process";
     java $TOOL -cp ./lib/*:./jdbc/* -Dlogback.configurationFile="/opt/ontop/log/logback.xml" -Dlogging.config="/opt/ontop/log/logback.xml" \
-      it.unibz.inf.ontop.cli.Ontop endpoint ${ONTOLOGY_FILE} ${MAPPING_FILE} \
+      it.unibz.inf.ontop.cli.Ontop endpoint ${ONTOLOGY} ${MAPPING} \
       ${PROPERTIES} ${PORTAL} ${DEV} ${ENDPOINT} ${CORS} ${LAZY}&
   fi
 done

--- a/provisioning/src/main/docker/Dockerfile
+++ b/provisioning/src/main/docker/Dockerfile
@@ -25,7 +25,7 @@ FROM ontop/ontop:5.1.2 as blueprint
 # Build Container: Fixes diverse vulnerabilities in guava <32, tomcat, spring-boot 2.7<13, spring-framework <5.3.28 and spring-web (all 5 versions - need to exclude a deprecated package from the jar)
 ##
 
-FROM eclipse-temurin:21-jdk AS build
+FROM eclipse-temurin:11-jdk AS build
 
 # run with docker --build-arg jdbcDrivers=path_to_my_driver to establish a different driver
 ARG jdbcDrivers="https://repo1.maven.org/maven2/com/h2database/h2/2.2.220/h2-2.2.220.jar https://download.dremio.com/jdbc-driver/dremio-jdbc-driver-LATEST.jar https://repo1.maven.org/maven2/org/apache/calcite/avatica/avatica/1.22.0/avatica-1.22.0.jar"
@@ -56,7 +56,7 @@ RUN  if [ "${HTTP_PROXY}" != ""  ]; then \
 # Target Container: Use a valid base image
 ##
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 
 ARG APP_USER=ontop
 ARG APP_UID=10001


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

This fix resolves two issues with the provisioning agent which appeared during the E2E Test 24.03 (shell script & JRE platform).
It also documents the version changes (on logback) and hardening efforts (on spring web) between the 1.10 and 1.11 lines.
Some github actions have been upgraded, too.

## WHY

Due to an erroneous command line, the ontology configurations were not taken from the environment variables correctly for all endpoints but the last.
Furthermore, when working against a virtualizer, such as dremio, the jdbc drives included in the image need to be compatible with the JRE version (else their network stack could run into connection problems).

## FURTHER NOTES

Dremio switched their driver model in a later/more current version from a proprietary to an open-source based generic one.
We should have a look at that for the 1.12.x line/24.05

Closes #81 
Closes #82 
