### PR TITLE
chore: add automated DAST scanning (courtesy of @RoKrish14).

### DIFF
--- a/.github/workflows/DAST.yml
+++ b/.github/workflows/DAST.yml
@@ -1,0 +1,128 @@
+---
+#
+#  Copyright (c) 2024 ZF Friedrichshafen AG
+#  Copyright (c) 2024 T-Systems International GmbH
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+name: ZAP_ALL
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  zap_scan1:
+    runs-on: ubuntu-latest
+    name: OWASP ZAP API Scan
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: API Test 1
+        id: api_test_1
+        run: |
+          # Perform API Test 1 and capture the response
+          response=$(curl -w "%{http_code}" -v GET https://knowledge.int.demo.catena-x.net/oem-provider-agent3/sparql?query=SELECT%20%3Fs%20WHERE%20%7B%20%3Fs%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23type%3E%20%3Chttps%3A%2F%2Fw3id.org%2Fcatenax%2Fontology%2Fvehicle%23Part%3E.%20%7D%20LIMIT%2010 --user "${{ secrets.BASIC_AUTH_USER }}:${{ secrets.BASIC_AUTH_PASSWORD }}")
+          echo "Response: $response"
+          
+      - name: API Test 2
+        id: api_test_2
+        run: |
+          # Perform API Test 2 and capture the response
+          response=$(curl -w "%{http_code}" -X GET https://knowledge.int.demo.catena-x.net/oem-provider-agent3/sparql?query=SELECT%20%3Fs%20WHERE%20%7B%20%3Fs%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23type%3E%20%3Chttps%3A%2F%2Fw3id.org%2Fcatenax%2Fontology%2Fvehicle%23Part%3E.%20%7D%20LIMIT%2010 --header "Authorization: Basic ${{ secrets.BASIC_AUTH_TOKEN }}")
+          echo "Response: $response"
+          
+      - name: API Test 3
+        id: api_test_3
+        run: |
+          # Perform API Test 3 and capture the response
+          response=$(curl -X POST https://knowledge.int.demo.catena-x.net/oem-edc-control/BPNL00000003COJN/management/v2/assets/request --header "X-Api-Key: ${{ secrets.API_KEY }}")
+          echo "Response: $response"
+          
+      - name: API Test 4
+        id: api_test_4
+        run: |
+          # Perform API Test 4 and capture the response
+          response=$(curl -X GET https://knowledge.int.demo.catena-x.net/tiera-edc-data/BPNL00000003CPIY/api/agent?query=SELECT%20%3Fs%20%3Fp%20%3Fo%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo.%7D%20LIMIT%2010 --header "Authorization: Bearer ${{ secrets.OAUTH2 }}")
+          echo "Response: $response"
+          
+      - name: Generating report skeletons
+        if: success() || failure()
+        run: |
+          touch API_report.html
+          chmod a+w API_report.html
+          ls -lrt
+          
+      - name: Run ZAP API scan
+        run: |
+          set +e
+          
+          echo "Pulling ZAP image..."
+          docker pull ghcr.io/zaproxy/zaproxy:stable -q
+          echo "Starting ZAP Docker container..."
+          docker run -v ${GITHUB_WORKSPACE}:/zap/wrk/:rw ghcr.io/zaproxy/zaproxy:stable zap-api-scan.py -t docs/openapi.json -f openapi -r API_report.html -T 1
+          
+          echo "... done."
+          
+      - name: Upload HTML report
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ZAP_API scan report
+          path: ./API_report.html
+          retention-days: 1
+          
+  zap_scan2:
+    runs-on: ubuntu-latest
+    name: OWASP ZAP FULL Scan
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Generating report skeletons
+        if: success() || failure()
+        run: |
+          touch fullscan_report.html
+          chmod a+w fullscan_report.html
+          ls -lrt
+          
+      - name: Perform ZAP FULL scan
+        run: |
+          set +e
+          
+          echo "Pulling ZAP image..."
+          docker pull ghcr.io/zaproxy/zaproxy:stable -q
+          echo "Starting ZAP Docker container..."
+          docker run -v ${GITHUB_WORKSPACE}:/zap/wrk/:rw ghcr.io/zaproxy/zaproxy:stable zap-full-scan.py -t https://knowledge.int.demo.catena-x.net -r fullscan_report.html -T 1
+          
+          echo "... done."
+          
+      - name: Upload HTML report
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ZAP_FULL scan report
+          path: ./fullscan_report.html
+          retention-days: 1

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -32,9 +32,7 @@ on:
 
   workflow_dispatch:
 
-  # Since rules may change should run regularily
-  schedule:
-    - cron: "0 0 * * *"
+
 
 jobs:
   analyze:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,6 +1,6 @@
 ---
 #
-#  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#  Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
 #
 #  See the NOTICE file(s) distributed with this work for additional
 #  information regarding copyright ownership.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <!--
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@
 
 # Tractus-X Knowledge Agents Reference Implementation (KA-RI) Documentation 
 
-In the Knowledge Agent Architecture, an Agent is any component which speaks and/or enacts a Semantic Web protocol, such as SPARQL.
+In the Knowledge Agent Architecture, an Agent is any component which speaks and/or enacts a Semantic Web protocol, such as SPARQL. So agents share a common [Open Api Specifaction](openapi.json) of which they implement a particular profile, i.e., a sub-protocol.
 
 Binding Agents are the intermediate layer between the dataspace (represented by the Matchmaking Agent that is connected to any Agent-Enabled Application and/or the Agent-Enabled Connector) and your business data & functions.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -207,6 +207,7 @@
             "style": "form",
             "explode": true,
             "schema": {
+              "maxItems": 128,
               "type": "array",
               "items": {
                 "type": "string"
@@ -322,6 +323,7 @@
                 "style": "simple",
                 "explode": false,
                 "schema": {
+                  "maxItems": 64,
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/CxWarning"
@@ -539,6 +541,7 @@
             "style": "form",
             "explode": true,
             "schema": {
+              "maxItems": 128,
               "type": "array",
               "items": {
                 "type": "string"
@@ -733,6 +736,7 @@
                 "style": "simple",
                 "explode": false,
                 "schema": {
+                  "maxItems": 64,
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/CxWarning"
@@ -1171,6 +1175,7 @@
             "style": "simple",
             "explode": false,
             "schema": {
+              "maxItems": 64,
               "type": "array",
               "items": {
                 "$ref": "#/components/schemas/CxWarning"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1391 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Catena-X Knowledge Agents SPARQL Endpoint Specification",
+    "description": "# Usage\n\nThis endpoint is designed after [W3C SparQL 1.1](https://www.w3.org/TR/sparql11-protocol/)\n\nIt is used in three places:\n- As the consumer-oriented entrypoint of a Matchmaking Agent into the dataspace\n- As the provider-oriented looking entrypoint of a Binding Agent to a backend system\n- As the \"transfer\" protocol between the transfer proxies as built by the EDC infrastructure\n\n### Examples\n\n1. Invoke a Parameterized Skill\n\n```\nPREFIX l0: <https://w3id.org/italia/onto/l0/>\nPREFIX cis: <http://dati.beniculturali.it/cis/>\nSELECT ?event ?eventName ?culturalProperty ?culturalPropertyLabel\nWHERE{\n  ?event cis:involvesCulturalEntity ?culturalProperty ;\n  l0:name ?eventName .\n  ?culturalProperty rdfs:label ?culturalPropertyLabel\n}\n```\n\n2. Invoke a Dataspace Query\n\n```\nPREFIX arco-catalogue: <https://w3id.org/arco/ontology/catalogue/>\nPREFIX roapit: <https://w3id.org/italia/onto/RO/>\nSELECT *\nWHERE{\n  ?entity arco-catalogue:hasCatalogueRecordVersion ?record . \n  ?record arco-catalogue:hasCatalogueRecordVersionRiT ?rit . \n  ?rit roapit:withRole ?role ;\n    roapit:isRoleInTimeOf ?agent\n}\n\n3. Sub-Skill of 2. that is transferred to the Binding Agent\n\n```\nPREFIX arco-catalogue: <https://w3id.org/arco/ontology/catalogue/>\nPREFIX roapit: <https://w3id.org/italia/onto/RO/>\nSELECT *\nWHERE{\n  ?entity arco-catalogue:hasCatalogueRecordVersion ?record . \n  ?record arco-catalogue:hasCatalogueRecordVersionRiT ?rit . \n  ?rit roapit:withRole ?role ;\n    roapit:isRoleInTimeOf ?agent\n}\n\n```\n",
+    "termsOfService": "http://catenax.io",
+    "contact": {
+      "email": "info@catenax.io"
+    },
+    "license": {
+      "name": "Eclipse Public License",
+      "url": "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version": "1.11.16"
+  },
+  "externalDocs": {
+    "description": "https://eclipse-tractusx.github.io/docs-kits/category/agents-kit",
+    "url": "https://eclipse-tractusx.github.io/docs-kits/kits/knowledge-agents/development-view/api"
+  },
+  "servers": [
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/conforming-agent/bind",
+      "description": "Development Conforming Agent for KA-BIND Profile"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/conforming-agent/match",
+      "description": "Development Conforming Agent for KA-MATCH Profile"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/conforming-agent/transfer",
+      "description": "Development Conforming Agent for KA-TRANSFER Profile"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/tiera-remoting-agent/rdf4j-server/repositories/prognosis",
+      "description": "Development Remoting Agent Prognosis Example"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/tiera-remoting-agent/rdf4j-server/repositories/rul",
+      "description": "Development Remoting Agent Remaining Useful Life Example"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/tiera-remoting-agent/rdf4j-server/repositories/health",
+      "description": "Development Remoting Agent Health Indicator Example"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/oem-provider-agent/sparql",
+      "description": "Development Provisioning Agent Endpoint 1"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/oem-provider-agent2/sparql",
+      "description": "Development Provisioning Agent Endpoint 2"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/oem-provider-agent3/sparql",
+      "description": "Development Provisioning Agent Endpoint 3"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/oem-provider-agent4/sparql",
+      "description": "Development Provisioning Agent Endpoint 4"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/oem-provider-agent5/sparql",
+      "description": "Development Provisioning Agent Endpoint 5"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/tiera-edc-data/BPNL00000003CPIY/api/agent",
+      "description": "Development Matchmaking Agent"
+    },
+    {
+      "url": "https://knowledge.dev.demo.catena-x.net/consumer-edc-data/BPNL00000003CQI9/api",
+      "description": "Development Consumer"
+    },
+    {
+      "url": "ttps://knowledge.dev.demo.catena-x.net/oem-edc-data/BPNL00000003COJN/api",
+      "description": "Development OEM"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    },
+    {
+      "BasicAuth": []
+    },
+    {
+      "OAuth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "agent",
+      "description": "Perform a SPARQL query against the dataspace"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Invoke a Skill or Query (Simple)",
+        "operationId": "getAgent",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "description": "The Target Asset of the Query (targets the complete dataspace if empty)",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "LifetimeSkill": {
+                "$ref": "#/components/examples/LifetimeSkill"
+              },
+              "NullSkill": {
+                "$ref": "#/components/examples/NullSkill"
+              },
+              "DataspaceSkill": {
+                "$ref": "#/components/examples/DataspaceSkill"
+              }
+            }
+          },
+          {
+            "name": "runMode",
+            "in": "query",
+            "description": "Determines the preferred execution location which may be \"consumer\" (in the computing environment of the endpoint agent), \"provider\" (in the computing environment of the remote agent providing the targetted asset) or \"all\" (the agent will choose the best computing environment based on contracts and policies, this is the default mode).",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "consumer": {
+                "$ref": "#/components/examples/RunModeConsumer"
+              },
+              "provider": {
+                "$ref": "#/components/examples/RunModeProvider"
+              },
+              "all": {
+                "$ref": "#/components/examples/RunModeAll"
+              }
+            }
+          },
+          {
+            "name": "queryLn",
+            "in": "query",
+            "description": "Determines the query language. Currently only \"SPARQL\" is supported.",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "sparql": {
+                "$ref": "#/components/examples/QuerySparql"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The SPARQL query",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Null": {
+                "$ref": "#/components/examples/NullText"
+              },
+              "Dataspace": {
+                "$ref": "#/components/examples/Dataspace"
+              }
+            }
+          },
+          {
+            "name": "(vin",
+            "in": "query",
+            "description": "A sample bound parameter 'vin' which opens a new input tuple",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Vehicle1": {
+                "$ref": "#/components/examples/Vehicle1"
+              },
+              "NoVehicle": {
+                "$ref": "#/components/examples/NoVehicle"
+              }
+            }
+          },
+          {
+            "name": "troubleCode",
+            "in": "query",
+            "description": "A sample multi-bound parameter 'troubleCode' which closes the tuple",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "examples": {
+              "TroubleCodeClose": {
+                "$ref": "#/components/examples/TroubleCodeClose"
+              },
+              "NoTroubleCode": {
+                "$ref": "#/components/examples/NoTroubleCode"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The SparQL query has been processed successfully.",
+            "content": {
+              "application/sparql-results+json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "head": {
+                    "vars": [
+                      "connector",
+                      "asset",
+                      "name",
+                      "description",
+                      "type",
+                      "version",
+                      "contentType",
+                      "isDefinedBy",
+                      "shape"
+                    ]
+                  },
+                  "results": {
+                    "bindings": [
+                      {
+                        "connector": {
+                          "type": "uri",
+                          "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                        },
+                        "asset": {
+                          "type": "uri",
+                          "value": "GraphAsset?oem=Quality"
+                        },
+                        "name": {
+                          "type": "literal",
+                          "value": "Quality Data."
+                        },
+                        "description": {
+                          "type": "literal",
+                          "value": "A graph asset/offering mounting Quality data."
+                        },
+                        "type": {
+                          "type": "uri,",
+                          "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                        },
+                        "version": {
+                          "type": "literal,",
+                          "value": "v0.7.2"
+                        },
+                        "contentType": {
+                          "type": "literal,",
+                          "value": "application/json, application/xml"
+                        },
+                        "isDefinedBy": {
+                          "type": "literal,",
+                          "value": "<https://w3id.org/catenax/ontology/reliability>"
+                        },
+                        "shape": {
+                          "type": "literal,",
+                          "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "application/sparql-results+xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/XmlResultset"
+                },
+                "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>https://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+                }
+              },
+              "text/tab-separated-values": {
+                "schema": {
+                  "type": "string",
+                  "example": "?subject ?predicate ?object"
+                }
+              },
+              "application/x-binary-rdf-results-table": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "203": {
+            "description": "The SparQL query has been processed successfully but warnings did occur.",
+            "headers": {
+              "cx_warnings": {
+                "description": "A data structure listing problems when processing the query.",
+                "style": "simple",
+                "explode": false,
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CxWarning"
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/sparql-results+json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "head": {
+                    "vars": [
+                      "connector",
+                      "asset",
+                      "name",
+                      "description",
+                      "type",
+                      "version",
+                      "contentType",
+                      "isDefinedBy",
+                      "shape"
+                    ]
+                  },
+                  "results": {
+                    "bindings": [
+                      {
+                        "connector": {
+                          "type": "uri",
+                          "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                        },
+                        "asset": {
+                          "type": "uri",
+                          "value": "GraphAsset?oem=Quality"
+                        },
+                        "name": {
+                          "type": "literal",
+                          "value": "Quality Data."
+                        },
+                        "description": {
+                          "type": "literal",
+                          "value": "A graph asset/offering mounting Quality data."
+                        },
+                        "type": {
+                          "type": "uri,",
+                          "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                        },
+                        "version": {
+                          "type": "literal,",
+                          "value": "v0.7.2"
+                        },
+                        "contentType": {
+                          "type": "literal,",
+                          "value": "application/json, application/xml"
+                        },
+                        "isDefinedBy": {
+                          "type": "literal,",
+                          "value": "<https://w3id.org/catenax/ontology/reliability>"
+                        },
+                        "shape": {
+                          "type": "literal,",
+                          "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "application/sparql-results+xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/XmlResultset"
+                },
+                "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>https://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+                }
+              },
+              "text/tab-separated-values": {
+                "schema": {
+                  "type": "string",
+                  "example": "?subject ?predicate ?object"
+                }
+              },
+              "application/x-binary-rdf-results-table": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request or malformed SPARQL"
+          },
+          "500": {
+            "description": "Fatal error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Invoke a Skill or Query (Flexible)",
+        "operationId": "postAgent",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "description": "The Target Asset of the Query (targets the complete dataspace if empty)",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "LifetimeSkill": {
+                "$ref": "#/components/examples/LifetimeSkill"
+              },
+              "NullSkill": {
+                "$ref": "#/components/examples/NullSkill"
+              },
+              "DataspaceSkill": {
+                "$ref": "#/components/examples/DataspaceSkill"
+              }
+            }
+          },
+          {
+            "name": "runMode",
+            "in": "query",
+            "description": "Determines the preferred execution location which may be \"consumer\" (in the computing environment of the endpoint agent), \"provider\" (in the computing environment of the remote agent providing the targetted asset) or \"all\" (the agent will choose the best computing environment based on contracts and policies, this is the default mode).",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "consumer": {
+                "$ref": "#/components/examples/RunModeConsumer"
+              },
+              "provider": {
+                "$ref": "#/components/examples/RunModeProvider"
+              },
+              "all": {
+                "$ref": "#/components/examples/RunModeAll"
+              }
+            }
+          },
+          {
+            "name": "queryLn",
+            "in": "query",
+            "description": "Determines the query language. Currently only \"SPARQL\" is supported.",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "sparql": {
+                "$ref": "#/components/examples/QuerySparql"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "The SPARQL query (in case that the body contains a tuple set)",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Null": {
+                "$ref": "#/components/examples/NullText"
+              },
+              "Dataspace": {
+                "$ref": "#/components/examples/Dataspace"
+              }
+            }
+          },
+          {
+            "name": "(vin",
+            "in": "query",
+            "description": "A sample bound parameter 'vin' which opens a new input tuple",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Vehicle1": {
+                "$ref": "#/components/examples/Vehicle1"
+              },
+              "NoVehicle": {
+                "$ref": "#/components/examples/NoVehicle"
+              }
+            }
+          },
+          {
+            "name": "troubleCode",
+            "in": "query",
+            "description": "A sample multi-bound parameter 'troubleCode' which closes the tuple",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "examples": {
+              "TroubleCodeClose": {
+                "$ref": "#/components/examples/TroubleCodeClose"
+              },
+              "NoTroubleCode": {
+                "$ref": "#/components/examples/NoTroubleCode"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The body either contains the query or a binding data set when a skill is invoked",
+          "content": {
+            "application/sparql-results+json": {
+              "schema": {
+                "type": "object"
+              },
+              "example": {
+                "head": {
+                  "vars": [
+                    "vin",
+                    "troubleCode"
+                  ]
+                },
+                "results": {
+                  "bindings": [
+                    {
+                      "vin": {
+                        "type": "literal",
+                        "value": "WBAAL31029PZ00001"
+                      },
+                      "troubleCode": {
+                        "type": "literal",
+                        "value": "P0746"
+                      }
+                    },
+                    {
+                      "vin": {
+                        "type": "literal",
+                        "value": "WBAAL31029PZ00001"
+                      },
+                      "troubleCode": {
+                        "type": "literal",
+                        "value": "P0745"
+                      }
+                    },
+                    {
+                      "vin": {
+                        "type": "literal",
+                        "value": "WBAAL31029PZ00002"
+                      },
+                      "troubleCode": {
+                        "type": "literal",
+                        "value": "P0744"
+                      }
+                    },
+                    {
+                      "vin": {
+                        "type": "literal",
+                        "value": "WBAAL31029PZ00003"
+                      },
+                      "troubleCode": {
+                        "type": "literal",
+                        "value": "P0743"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "application/sparql-results+xml": {
+              "schema": {
+                "$ref": "#/components/schemas/XmlResultset"
+              },
+              "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"vin\"/>\n        <variable name=\"troubleCode\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"vin\">\n              <literal>WBAAL31029PZ00001</literal>\n            </binding>\n            <binding name=\"troubleCode\">\n              <literal>P0746</literal>\n            </binding>\n        </result>\n        <result>\n            <binding name=\"vin\">\n              <literal>WBAAL31029PZ00001</literal>\n            </binding>\n            <binding name=\"troubleCode\">\n              <literal>P0745</literal>\n            </binding>\n        </result>\n        <result>\n            <binding name=\"vin\">\n              <literal>WBAAL31029PZ00002</literal>\n            </binding>\n            <binding name=\"troubleCode\">\n              <literal>P0744</literal>\n            </binding>\n        </result>\n      </results>\n    </sparql>"
+            },
+            "application/sparql-query": {
+              "schema": {
+                "type": "string"
+              },
+              "examples": {
+                "Dataspace": {
+                  "$ref": "#/components/examples/Dataspace"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The SparQL query has been processed successfully.",
+            "content": {
+              "application/sparql-results+json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "head": {
+                    "vars": [
+                      "connector",
+                      "asset",
+                      "name",
+                      "description",
+                      "type",
+                      "version",
+                      "contentType",
+                      "isDefinedBy",
+                      "shape"
+                    ]
+                  },
+                  "results": {
+                    "bindings": [
+                      {
+                        "connector": {
+                          "type": "uri",
+                          "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                        },
+                        "asset": {
+                          "type": "uri",
+                          "value": "GraphAsset?oem=Quality"
+                        },
+                        "name": {
+                          "type": "literal",
+                          "value": "Quality Data."
+                        },
+                        "description": {
+                          "type": "literal",
+                          "value": "A graph asset/offering mounting Quality data."
+                        },
+                        "type": {
+                          "type": "uri,",
+                          "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                        },
+                        "version": {
+                          "type": "literal,",
+                          "value": "v0.7.2"
+                        },
+                        "contentType": {
+                          "type": "literal,",
+                          "value": "application/json, application/xml"
+                        },
+                        "isDefinedBy": {
+                          "type": "literal,",
+                          "value": "<https://w3id.org/catenax/ontology/reliability>"
+                        },
+                        "shape": {
+                          "type": "literal,",
+                          "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "application/sparql-results+xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/XmlResultset"
+                },
+                "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>https://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+                }
+              },
+              "text/tab-separated-values": {
+                "schema": {
+                  "type": "string",
+                  "example": "?subject ?predicate ?object"
+                }
+              },
+              "application/x-binary-rdf-results-table": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "203": {
+            "description": "The SparQL query has been processed successfully but warnings did occur.",
+            "headers": {
+              "cx_warnings": {
+                "description": "A data structure listing problems when processing the query.",
+                "style": "simple",
+                "explode": false,
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CxWarning"
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/sparql-results+json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "head": {
+                    "vars": [
+                      "connector",
+                      "asset",
+                      "name",
+                      "description",
+                      "type",
+                      "version",
+                      "contentType",
+                      "isDefinedBy",
+                      "shape"
+                    ]
+                  },
+                  "results": {
+                    "bindings": [
+                      {
+                        "connector": {
+                          "type": "uri",
+                          "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                        },
+                        "asset": {
+                          "type": "uri",
+                          "value": "GraphAsset?oem=Quality"
+                        },
+                        "name": {
+                          "type": "literal",
+                          "value": "Quality Data."
+                        },
+                        "description": {
+                          "type": "literal",
+                          "value": "A graph asset/offering mounting Quality data."
+                        },
+                        "type": {
+                          "type": "uri,",
+                          "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                        },
+                        "version": {
+                          "type": "literal,",
+                          "value": "v0.7.2"
+                        },
+                        "contentType": {
+                          "type": "literal,",
+                          "value": "application/json, application/xml"
+                        },
+                        "isDefinedBy": {
+                          "type": "literal,",
+                          "value": "<https://w3id.org/catenax/ontology/reliability>"
+                        },
+                        "shape": {
+                          "type": "literal,",
+                          "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "application/sparql-results+xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/XmlResultset"
+                },
+                "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>https://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+                }
+              },
+              "text/tab-separated-values": {
+                "schema": {
+                  "type": "string",
+                  "example": "?subject ?predicate ?object"
+                }
+              },
+              "application/x-binary-rdf-results-table": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request or malformed SPARQL"
+          },
+          "500": {
+            "description": "Fatal error"
+          }
+        }
+      }
+    },
+    "/skill": {
+      "post": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Register a Skill",
+        "operationId": "postSkill",
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "description": "The Target Asset of the Query (targets the complete dataspace if empty)",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "DataspaceSkill": {
+                "$ref": "#/components/examples/DataspaceSkill"
+              },
+              "LifetimeSkill": {
+                "$ref": "#/components/examples/LifetimeSkill"
+              }
+            }
+          },
+          {
+            "name": "distributionMode",
+            "in": "query",
+            "description": "The distribution mode under which to publish the skill",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Provider": {
+                "$ref": "#/components/examples/DistributionModeProvider"
+              },
+              "Consumer": {
+                "$ref": "#/components/examples/DistributionModeConsumer"
+              },
+              "All": {
+                "$ref": "#/components/examples/DistributionModeAll"
+              }
+            }
+          },
+          {
+            "name": "contract",
+            "in": "query",
+            "description": "The contract under which the skill should be published",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Provider": {
+                "$ref": "#/components/examples/Contract"
+              }
+            }
+          },
+          {
+            "name": "isFederated",
+            "in": "query",
+            "description": "Whether the skill should be visible in the Federated Catalogue",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "ontology",
+            "in": "query",
+            "description": "Multiple references to ontologies which are referenced in the skill",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Provider": {
+                "$ref": "#/components/examples/Ontology"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The body either contains the parameterized query",
+          "content": {
+            "application/sparql-query": {
+              "schema": {
+                "type": "string"
+              },
+              "examples": {
+                "Dataspace": {
+                  "$ref": "#/components/examples/Dataspace"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Skill has been registered"
+          },
+          "204": {
+            "description": "Skill has been updated"
+          },
+          "400": {
+            "description": "Bad request or malformed SPARQL"
+          },
+          "500": {
+            "description": "Fatal error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CxWarning": {
+        "type": "object",
+        "properties": {
+          "source-tenant": {
+            "type": "string"
+          },
+          "source-asset": {
+            "type": "string"
+          },
+          "target-tenant": {
+            "type": "string"
+          },
+          "target-asset": {
+            "type": "string"
+          },
+          "problem": {
+            "type": "string"
+          },
+          "context": {
+            "type": "string"
+          }
+        }
+      },
+      "XmlResultset": {
+        "type": "object",
+        "properties": {
+          "head": {
+            "$ref": "#/components/schemas/XmlResultset_head"
+          },
+          "results": {
+            "$ref": "#/components/schemas/XmlResultset_results"
+          }
+        },
+        "xml": {
+          "name": "sparql"
+        }
+      },
+      "XmlResultset_head_variable": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "xml": {
+              "attribute": true
+            }
+          }
+        },
+        "xml": {
+          "name": "variable"
+        }
+      },
+      "XmlResultset_head": {
+        "type": "object",
+        "properties": {
+          "variable": {
+            "$ref": "#/components/schemas/XmlResultset_head_variable"
+          }
+        },
+        "xml": {
+          "name": "head"
+        }
+      },
+      "XmlResultset_results_result_binding": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "xml": {
+              "attribute": true
+            }
+          },
+          "literal": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "binding"
+        }
+      },
+      "XmlResultset_results_result": {
+        "type": "object",
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/XmlResultset_results_result_binding"
+          }
+        },
+        "xml": {
+          "name": "result"
+        }
+      },
+      "XmlResultset_results": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/XmlResultset_results_result"
+          }
+        },
+        "xml": {
+          "name": "results"
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "The SparQL query has been processed successfully.",
+        "content": {
+          "application/sparql-results+json": {
+            "schema": {
+              "type": "object"
+            },
+            "example": {
+              "head": {
+                "vars": [
+                  "connector",
+                  "asset",
+                  "name",
+                  "description",
+                  "type",
+                  "version",
+                  "contentType",
+                  "isDefinedBy",
+                  "shape"
+                ]
+              },
+              "results": {
+                "bindings": [
+                  {
+                    "connector": {
+                      "type": "uri",
+                      "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                    },
+                    "asset": {
+                      "type": "uri",
+                      "value": "GraphAsset?oem=Quality"
+                    },
+                    "name": {
+                      "type": "literal",
+                      "value": "Quality Data."
+                    },
+                    "description": {
+                      "type": "literal",
+                      "value": "A graph asset/offering mounting Quality data."
+                    },
+                    "type": {
+                      "type": "uri,",
+                      "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                    },
+                    "version": {
+                      "type": "literal,",
+                      "value": "v0.7.2"
+                    },
+                    "contentType": {
+                      "type": "literal,",
+                      "value": "application/json, application/xml"
+                    },
+                    "isDefinedBy": {
+                      "type": "literal,",
+                      "value": "<https://w3id.org/catenax/ontology/reliability>"
+                    },
+                    "shape": {
+                      "type": "literal,",
+                      "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "application/sparql-results+xml": {
+            "schema": {
+              "$ref": "#/components/schemas/XmlResultset"
+            },
+            "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>hhttps://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+          },
+          "text/csv": {
+            "schema": {
+              "type": "string",
+              "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+            }
+          },
+          "text/tab-separated-values": {
+            "schema": {
+              "type": "string",
+              "example": "?subject ?predicate ?object"
+            }
+          },
+          "application/x-binary-rdf-results-table": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "203": {
+        "description": "The SparQL query has been processed successfully but warnings did occur.",
+        "headers": {
+          "cx_warnings": {
+            "description": "A data structure listing problems when processing the query.",
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CxWarning"
+              }
+            }
+          }
+        },
+        "content": {
+          "application/sparql-results+json": {
+            "schema": {
+              "type": "object"
+            },
+            "example": {
+              "head": {
+                "vars": [
+                  "connector",
+                  "asset",
+                  "name",
+                  "description",
+                  "type",
+                  "version",
+                  "contentType",
+                  "isDefinedBy",
+                  "shape"
+                ]
+              },
+              "results": {
+                "bindings": [
+                  {
+                    "connector": {
+                      "type": "uri",
+                      "value": "edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN"
+                    },
+                    "asset": {
+                      "type": "uri",
+                      "value": "GraphAsset?oem=Quality"
+                    },
+                    "name": {
+                      "type": "literal",
+                      "value": "Quality Data."
+                    },
+                    "description": {
+                      "type": "literal",
+                      "value": "A graph asset/offering mounting Quality data."
+                    },
+                    "type": {
+                      "type": "uri,",
+                      "value": "https://w3id.org/catenax/ontology/common#GraphAsset"
+                    },
+                    "version": {
+                      "type": "literal,",
+                      "value": "v0.7.2"
+                    },
+                    "contentType": {
+                      "type": "literal,",
+                      "value": "application/json, application/xml"
+                    },
+                    "isDefinedBy": {
+                      "type": "literal,",
+                      "value": "<https://w3id.org/catenax/ontology/reliability>"
+                    },
+                    "shape": {
+                      "type": "literal,",
+                      "value": "@prefix : <GraphAsset?oem=Quality#> ."
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "application/sparql-results+xml": {
+            "schema": {
+              "$ref": "#/components/schemas/XmlResultset"
+            },
+            "example": "<?xml version=\"1.0\"?>\n<sparql xmlns=\"http://www.w3.org/2005/sparql-results#\">\n    <head>\n        <variable name=\"connector\"/>\n        <variable name=\"asset\"/>\n        <variable name=\"name\"/>\n        <variable name=\"description\"/>\n        <variable name=\"type\"/>\n        <variable name=\"version\"/>\n        <variable name=\"contentType\"/>\n        <variable name=\"isDefinedBy\"/>\n        <variable name=\"shape\"/>\n    </head>\n    <results>\n        <result>\n            <binding name=\"connector\">\n                <uri>edcs://knowledge.dev.demo.catena-x.net/oem-edc-control/BPNL00000003COJN</uri>\n            </binding>\n            <binding name=\"asset\">\n                <uri>GraphAsset?oem=Quality</uri>\n            </binding>\n            <binding name=\"name\">\n                <literal>Quality Data.</literal>\n            </binding>\n            <binding name=\"description\">\n                <literal>A graph asset/offering mounting Quality data.</literal>\n            </binding>\n            <binding name=\"type\">\n                <uri>https://w3id.org/catenax/ontology/common#GraphAsset</uri>\n            </binding>\n            <binding name=\"version\">\n                <literal>v0.7.2</literal>\n            </binding>\n            <binding name=\"contentType\">\n                <literal>application/json, application/xml</literal>\n            </binding>\n            <binding name=\"isDefinedBy\">\n                <literal>&lt;https://w3id.org/catenax/ontology/reliability&gt;</literal>\n            </binding>\n            <binding name=\"shape\">\n                <literal>@prefix : &lt;GraphAsset?oem=Quality#&gt; .</literal>\n            </binding>\n        </result>\n    </results>\n</sparql>"
+          },
+          "text/csv": {
+            "schema": {
+              "type": "string",
+              "example": "\"subject\",\"predicate\",\"object\"\n\"foo\",\"meets\",\"bar\"\n\"one\",\"meets\",\"two\""
+            }
+          },
+          "text/tab-separated-values": {
+            "schema": {
+              "type": "string",
+              "example": "?subject ?predicate ?object"
+            }
+          },
+          "application/x-binary-rdf-results-table": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "400": {
+        "description": "Bad request or malformed SPARQL"
+      },
+      "500": {
+        "description": "Fatal error"
+      }
+    },
+    "examples": {
+      "NullSkill": {
+        "summary": "No Predefined Skill",
+        "value": null
+      },
+      "DataspaceSkill": {
+        "summary": "Predefined Skill to List Federated Data Catalogue",
+        "value": "SkillAsset?consumer=Dataspace"
+      },
+      "LifetimeSkill": {
+        "summary": "Predefined Skill to Perform a Lifetime Prognosis",
+        "value": "SkillAsset?consumer=RemainingUsefulLife"
+      },
+      "Vehicle1": {
+        "summary": "Vehicle Parameter",
+        "value": "WBAAL31029PZ00001"
+      },
+      "NoVehicle": {
+        "summary": "No Vehicle Parameter",
+        "value": null
+      },
+      "TroubleCodeClose": {
+        "summary": "Multiple Trouble Codes (and Tuple End)",
+        "value": [
+          "P0746",
+          "P0745)"
+        ]
+      },
+      "SingleTroubleCode": {
+        "summary": "A Single Trouble Code",
+        "value": "P0746"
+      },
+      "NoTroubleCode": {
+        "summary": "No Trouble Code",
+        "value": null
+      },
+      "NullText": {
+        "summary": "No Skill",
+        "value": null
+      },
+      "Dataspace": {
+        "summary": "Skill to List Federated Data Catalogue",
+        "value": "SELECT ?connector ?asset \n       ?name\n       (MIN(?adescription) AS ?description) \n       ?type\n       (MAX(?aversion) AS ?version) \n       (GROUP_CONCAT(DISTINCT ?acontentType;SEPARATOR=\",\") AS ?contentType) \n       (CONCAT(\"<\",GROUP_CONCAT(?aontology;SEPARATOR=\">,<\"),\">\") AS ?isDefinedBy) \n       (MIN(?ashape) AS ?shape)\n WHERE { \n     ?connector <https://github.com/catenax-ng/product-knowledge/ontology/cx.ttl#offersAsset> ?asset. \n     ?asset <https://github.com/catenax-ng/product-knowledge/ontology/common_ontology.ttl#contentType> ?acontentType; \n            <https://github.com/catenax-ng/product-knowledge/ontology/common_ontology.ttl#name> ?name; \n            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type; \n            <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> ?aontology; \n            <https://github.com/catenax-ng/product-knowledge/ontology/common_ontology.ttl#version> ?aversion; \n            <https://github.com/catenax-ng/product-knowledge/ontology/common_ontology.ttl#description> ?adescription.\n\n    OPTIONAL {\n        ?asset <https://github.com/catenax-ng/product-knowledge/ontology/cx.ttl#shape> ?ashape\n    }\n} GROUP BY ?connector ?asset ?name ?type"
+      },
+      "Resultset": {
+        "summary": "Sample Json-Based Resultset"
+      },
+      "AuthorsWithLimits": {
+        "summary": "First 10 authors",
+        "value": "SELECT DISTINCT \n  ?author_url \n  (GROUP_CONCAT(?author_label; SEPARATOR=\";\") AS ?author_names)\n{ \n\n ?author_url a-cd:pseudonym ?x .\n ?author_url rdfs:label ?author_label\n} LIMIT 10"
+      },
+      "CulturalPlacesInVinci": {
+        "summary": "Cultural places in Latina",
+        "value": "SELECT DISTINCT ?luogo ?indirizzo ?comune WHERE {\n ?x a cis:CulturalInstituteOrSite ;\n  cis:institutionalCISName ?luogo ;\n  cis:hasSite ?site .\n ?site cis:siteAddress ?address .\n ?address clvapit:fullAddress ?indirizzo ;\n          clvapit:hasCity [rdfs:label ?comune] .\n FILTER regex(str(?comune), \"Vinci\", \"i\")\n}  ORDER BY ?luogo LIMIT 100\nLifetimeSkill:"
+      },
+      "RunModeConsumer": {
+        "summary": "Local Consumer Execution",
+        "value": "consumer"
+      },
+      "RunModeProvider": {
+        "summary": "Remote Provider Execution",
+        "value": "provider"
+      },
+      "RunModeAll": {
+        "summary": "Best Possible Execution",
+        "value": "all"
+      },
+      "DistributionModeConsumer": {
+        "summary": "Local Consumer Execution",
+        "value": "CONSUMER"
+      },
+      "DistributionModeProvider": {
+        "summary": "Remote Provider Execution",
+        "value": "PROVIDER"
+      },
+      "DistributionModeAll": {
+        "summary": "Best Possible Execution",
+        "value": "ALL"
+      },
+      "QuerySparql": {
+        "summary": "SPARQL Query Language",
+        "value": "SPARQL"
+      },
+      "Contract": {
+        "summary": "An example contract name",
+        "value": "Contract?oem=Skill"
+      },
+      "Ontology": {
+        "summary": "An example reference to an ontology",
+        "value": "https://w3id.org/catenax/ontology/behaviour"
+      }
+    },
+    "securitySchemes": {
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      },
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/auth",
+            "tokenUrl": "https://centralidp.int.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

This PR introduces automated (and manual) DAST scanning using ZAP.

## WHY

Manual DAST scanning is a tedious but critical effort. ZAP can be automated to perform these scans regularly and give more immediate feedback. 

## FURTHER NOTES

Please set the following (repository) secrets before activating/merging this PR (by personal communication with the requestor)

![image](https://github.com/eclipse-tractusx/knowledge-agents/assets/3089344/80c99848-d9c7-483e-bfe9-047487cd0f44)

