### PR TITLE
fix: check connector urls and headers coming from config.

### DIFF
--- a/matchmaking/src/main/java/org/eclipse/tractusx/agents/http/DelegationServiceImpl.java
+++ b/matchmaking/src/main/java/org/eclipse/tractusx/agents/http/DelegationServiceImpl.java
@@ -185,8 +185,7 @@ public class DelegationServiceImpl implements DelegationService {
         return new DelegationResponse(sendRequest(newRequest, response), Response.status(response.getStatus()).build());
     }
 
-    protected static final Pattern PARAMETER_KEY_ALLOW = Pattern.compile("^(?<param>(?!asset$)[^&?=]+)$");
-    protected static final Pattern PARAMETER_VALUE_ALLOW = Pattern.compile("^(?<value>[^&]+)$");
+
 
     /**
      * computes the url to target the given data plane
@@ -211,11 +210,11 @@ public class DelegationServiceImpl implements DelegationService {
         HttpUrl.Builder httpBuilder = Objects.requireNonNull(okhttp3.HttpUrl.parse(url)).newBuilder();
         for (Map.Entry<String, List<String>> param : uri.getQueryParameters().entrySet()) {
             String key = param.getKey();
-            Matcher keyMatcher = PARAMETER_KEY_ALLOW.matcher(key);
+            Matcher keyMatcher = AgentConfig.PARAMETER_KEY_ALLOW.matcher(key);
             if (keyMatcher.matches()) {
                 String recodeKey = HttpUtils.urlEncodeParameter(keyMatcher.group("param"));
                 for (String value : param.getValue()) {
-                    Matcher valueMatcher = PARAMETER_VALUE_ALLOW.matcher(value);
+                    Matcher valueMatcher = AgentConfig.PARAMETER_VALUE_ALLOW.matcher(value);
                     if (valueMatcher.matches()) {
                         String recodeValue = HttpUtils.urlEncodeParameter(valueMatcher.group("value"));
                         httpBuilder = httpBuilder.addQueryParameter(recodeKey, recodeValue);


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Improves url and header checking in AgentConfig.

## WHY

CodeQL complains about some potential SSF traps.

## FURTHER NOTES

Wrt to sanitizing other dynamic SSF sources which CodeQL may not correctly detect, please have a look at:
- https://github.com/eclipse-tractusx/knowledge-agents/blob/05827e257934542c8015201611f0d43c37944d71/matchmaking/src/main/java/org/eclipse/tractusx/agents/http/GraphController.java#L155 ff
-  https://github.com/eclipse-tractusx/knowledge-agents/blob/05827e257934542c8015201611f0d43c37944d71/matchmaking/src/main/java/org/eclipse/tractusx/agents/http/DelegationServiceImpl.java#L215 ff
- https://github.com/eclipse-tractusx/knowledge-agents/blob/05827e257934542c8015201611f0d43c37944d71/matchmaking/src/main/java/org/eclipse/tractusx/agents/http/DelegationServiceImpl.java#L219 ff

Closes #128
